### PR TITLE
Add fifth coaching block for executives

### DIFF
--- a/src/components/Coaching.tsx
+++ b/src/components/Coaching.tsx
@@ -2,6 +2,7 @@
 
 import {
   BikeIcon,
+  BriefcaseIcon,
   RunIcon,
   SwimmerIcon,
   TriathlonIcon,
@@ -67,6 +68,13 @@ export default function Coaching({ t }: Props) {
       description: t.coaching.serviceDescriptions.triathlon,
       highlight: t.coaching.highlights.triathlon,
     },
+    {
+      icon: BriefcaseIcon,
+      title: t.coaching.services.executive,
+      gradient: "from-ocean-800 to-ocean-900",
+      description: t.coaching.serviceDescriptions.executive,
+      highlight: t.coaching.highlights.executive,
+    },
   ];
 
   return (
@@ -95,7 +103,7 @@ export default function Coaching({ t }: Props) {
         />
 
         {/* Services Grid */}
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-5">
           {services.map((service, index) => (
             <motion.div
               key={index}

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -337,3 +337,16 @@ export const TriathlonIcon = ({
     />
   </svg>
 );
+
+export const BriefcaseIcon = ({
+  size = 16,
+  className = "",
+  color = "currentColor",
+}: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 512 512" className={className}>
+    <path
+      fill={color}
+      d="M184 48H328c4.4 0 8 3.6 8 8V96H176V56c0-4.4 3.6-8 8-8zm-56 8V96H64C28.7 96 0 124.7 0 160v96H192 320 512V160c0-35.3-28.7-64-64-64H384V56c0-30.9-25.1-56-56-56H184c-30.9 0-56 25.1-56 56zM512 288H320v32c0 17.7-14.3 32-32 32H224c-17.7 0-32-14.3-32-32V288H0V416c0 35.3 28.7 64 64 64H448c35.3 0 64-28.7 64-64V288z"
+    />
+  </svg>
+);

--- a/src/lib/translations/en.ts
+++ b/src/lib/translations/en.ts
@@ -51,12 +51,14 @@ export const en = {
       bike: "Cycling",
       run: "Running",
       triathlon: "Triathlon",
+      executive: "Coaching for executives",
     },
     serviceDescriptions: {
       swim: "Technique training and individual training plans",
       bike: "Individual training plans",
       run: "Individual training plans",
       triathlon: "Individual training plans",
+      executive: "Lifestyle & mental coaching",
     },
     cta: {
       title: "Ready to Maximize Your Performance?",
@@ -69,6 +71,7 @@ export const en = {
       bike: "Cycling",
       run: "Running",
       triathlon: "Triathlon",
+      executive: "Executive",
     },
   },
 

--- a/src/lib/translations/nl.ts
+++ b/src/lib/translations/nl.ts
@@ -50,12 +50,14 @@ export const nl = {
       bike: "Wielrennen",
       run: "Lopen",
       triathlon: "Triatlon",
+      executive: "Coaching voor executives",
     },
     serviceDescriptions: {
       swim: "Techniektraining en individuele trainingsschema's",
       bike: "Individuele trainingsschema's",
       run: "Individuele trainingsschema's",
       triathlon: "Individuele trainingsschema's",
+      executive: "Lifestyle & mentale coaching",
     },
     cta: {
       title: "Klaar om je prestaties te maximaliseren?",
@@ -68,6 +70,7 @@ export const nl = {
       bike: "Wielrennen",
       run: "Lopen",
       triathlon: "Triatlon",
+      executive: "Executive",
     },
   },
 


### PR DESCRIPTION
- Add BriefcaseIcon component for executive coaching
- Add "Coaching for executives" service with "Lifestyle & mental coaching" subtitle
- Update English and Dutch translations
- Update Coaching component to display 5 coaching blocks in responsive grid
- Change grid layout from 4 to 5 columns on large screens

Fixes #30