### PR TITLE
instagram link veranderd

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,7 @@ export const socialLinks = [
     platform: "Facebook",
   },
   {
-    href: "https://www.instagram.com/wardpel/",
+    href: "https://www.instagram.com/pellegrims.coach/",
     icon: InstagramIcon,
     platform: "Instagram",
   },


### PR DESCRIPTION
instagram link moet linken naar https://www.instagram.com/pellegrims.coach (gebruikersnaam werd veranderd)

closes #32
