### PR TITLE
Improve landing and group training freshness with tag-based cache revalidation

### DIFF
--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload";
+import { revalidateLandingProjectContent } from "@/lib/revalidate-site-content";
 
 export const Media: CollectionConfig = {
   slug: "media",
@@ -7,6 +8,10 @@ export const Media: CollectionConfig = {
     create: ({ req: { user } }) => !!user,
     update: ({ req: { user } }) => !!user,
     delete: ({ req: { user } }) => !!user,
+  },
+  hooks: {
+    afterChange: [({ context }) => revalidateLandingProjectContent(context)],
+    afterDelete: [({ context }) => revalidateLandingProjectContent(context)],
   },
   admin: {
     useAsTitle: "filename",

--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload";
+import { revalidateLandingProjectContent } from "@/lib/revalidate-site-content";
 
 export const Projects: CollectionConfig = {
   slug: "projects",
@@ -18,6 +19,10 @@ export const Projects: CollectionConfig = {
     create: ({ req: { user } }) => !!user,
     update: ({ req: { user } }) => !!user,
     delete: ({ req: { user } }) => !!user,
+  },
+  hooks: {
+    afterChange: [({ context }) => revalidateLandingProjectContent(context)],
+    afterDelete: [({ context }) => revalidateLandingProjectContent(context)],
   },
   admin: {
     useAsTitle: "title",

--- a/src/collections/SportCategories.ts
+++ b/src/collections/SportCategories.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from "payload";
+import { revalidateLandingProjectContent } from "@/lib/revalidate-site-content";
 
 export const SportCategories: CollectionConfig = {
   slug: "sport-categories",
@@ -18,6 +19,10 @@ export const SportCategories: CollectionConfig = {
     create: ({ req: { user } }) => !!user,
     update: ({ req: { user } }) => !!user,
     delete: ({ req: { user } }) => !!user,
+  },
+  hooks: {
+    afterChange: [({ context }) => revalidateLandingProjectContent(context)],
+    afterDelete: [({ context }) => revalidateLandingProjectContent(context)],
   },
   admin: {
     useAsTitle: "key",

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,0 +1,6 @@
+export const LANDING_PROJECTS_TAG = "landing:projects";
+export const LANDING_GROUP_TRAININGS_TAG = "landing:group-trainings";
+
+export function getGroupTrainingDetailTag(slug: string): string {
+  return `group-training:detail:${slug}`;
+}

--- a/src/lib/group-trainings/get-group-trainings.ts
+++ b/src/lib/group-trainings/get-group-trainings.ts
@@ -1,8 +1,10 @@
 import "server-only";
 
+import { unstable_cache } from "next/cache";
 import { getPayload } from "payload";
 import config from "@/payload.config";
 import type { Locale } from "@/lib/i18n";
+import { LANDING_GROUP_TRAININGS_TAG } from "@/lib/cache-tags";
 import { getSeasonBadge } from "@/lib/group-trainings/season";
 import { getTranslations } from "@/lib/translations";
 
@@ -19,50 +21,60 @@ export type GroupTrainingCard = {
 export async function getGroupTrainingCards(
   locale: Locale
 ): Promise<GroupTrainingCard[]> {
+  const getCachedGroupTrainingCards = unstable_cache(
+    async (): Promise<GroupTrainingCard[]> => {
+      const detailTranslations = getTranslations(locale).groupTrainingDetail;
+      const seasonLabels = detailTranslations.seasons;
+      const payload = await getPayload({ config });
+      const result = await payload.find({
+        collection: "group-trainings",
+        limit: 50,
+        locale,
+        fallbackLocale: "en",
+        sort: "sortOrder",
+        where: {
+          _status: {
+            equals: "published",
+          },
+        },
+      });
+
+      return result.docs.flatMap((item): GroupTrainingCard[] => {
+        const title = item.title?.trim();
+        const badge =
+          getSeasonBadge(seasonLabels, item.sessionDates) ||
+          item.subtitle?.trim();
+        const description = item.subtitle?.trim();
+        const level = detailTranslations.levels[item.level]?.trim();
+        const slug = item.slug?.trim();
+
+        if (!title || !badge || !description || !level || !slug) {
+          return [];
+        }
+
+        const link = `/${locale}/groepen/${slug}`;
+
+        return [
+          {
+            title,
+            subtitle: badge,
+            description,
+            levelLabel: detailTranslations.levelLabel,
+            levelKey: item.level,
+            level,
+            link,
+          },
+        ];
+      });
+    },
+    ["group-training-cards", locale],
+    {
+      tags: [LANDING_GROUP_TRAININGS_TAG],
+    }
+  );
+
   try {
-    const detailTranslations = getTranslations(locale).groupTrainingDetail;
-    const seasonLabels = detailTranslations.seasons;
-    const payload = await getPayload({ config });
-    const result = await payload.find({
-      collection: "group-trainings",
-      limit: 50,
-      locale,
-      fallbackLocale: "en",
-      sort: "sortOrder",
-      where: {
-        _status: {
-          equals: "published",
-        },
-      },
-    });
-
-    return result.docs.flatMap((item): GroupTrainingCard[] => {
-      const title = item.title?.trim();
-      const badge =
-        getSeasonBadge(seasonLabels, item.sessionDates) ||
-        item.subtitle?.trim();
-      const description = item.subtitle?.trim();
-      const level = detailTranslations.levels[item.level]?.trim();
-      const slug = item.slug?.trim();
-
-      if (!title || !badge || !description || !level || !slug) {
-        return [];
-      }
-
-      const link = `/${locale}/groepen/${slug}`;
-
-      return [
-        {
-          title,
-          subtitle: badge,
-          description,
-          levelLabel: detailTranslations.levelLabel,
-          levelKey: item.level,
-          level,
-          link,
-        },
-      ];
-    });
+    return await getCachedGroupTrainingCards();
   } catch (error) {
     console.warn("Failed to load group trainings from Payload:", error);
     return [];

--- a/src/lib/group-trainings/group-training-detail.ts
+++ b/src/lib/group-trainings/group-training-detail.ts
@@ -1,8 +1,12 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
 import { getPayload } from "payload";
 import type { GroupTraining, Location } from "@/payload-types";
 import type { Locale } from "@/lib/i18n";
 import type { TrainingPageConfig } from "@/components/templates";
 import type { TranslationKey } from "@/lib/translations";
+import { getGroupTrainingDetailTag } from "@/lib/cache-tags";
 import { getSeasonBadge } from "@/lib/group-trainings/season";
 import config from "@/payload.config";
 
@@ -60,25 +64,40 @@ export async function getPublishedGroupTraining(
   locale: Locale,
   slug: string
 ): Promise<GroupTraining | null> {
-  const payload = await getPayload({ config });
+  const getCachedPublishedGroupTraining = unstable_cache(
+    async (): Promise<GroupTraining | null> => {
+      const payload = await getPayload({ config });
 
-  return (
-    (
-      await payload.find({
-        collection: "group-trainings",
-        limit: 1,
-        depth: 1,
-        locale,
-        fallbackLocale: "en",
-        where: {
-          and: [
-            { slug: { equals: slug } },
-            { _status: { equals: "published" } },
-          ],
-        },
-      })
-    ).docs[0] ?? null
+      return (
+        (
+          await payload.find({
+            collection: "group-trainings",
+            limit: 1,
+            depth: 1,
+            locale,
+            fallbackLocale: "en",
+            where: {
+              and: [
+                { slug: { equals: slug } },
+                { _status: { equals: "published" } },
+              ],
+            },
+          })
+        ).docs[0] ?? null
+      );
+    },
+    ["group-training-detail", locale, slug],
+    {
+      tags: [getGroupTrainingDetailTag(slug)],
+    }
   );
+
+  try {
+    return await getCachedPublishedGroupTraining();
+  } catch (error) {
+    console.warn("Failed to load group training detail from Payload:", error);
+    return null;
+  }
 }
 
 export function buildTrainingConfig(

--- a/src/lib/projects/get-projects.ts
+++ b/src/lib/projects/get-projects.ts
@@ -1,65 +1,74 @@
 import "server-only";
 
 import { getPayload } from "payload";
-import { unstable_noStore as noStore } from "next/cache";
+import { unstable_cache } from "next/cache";
 import type { Project as CardProject } from "@/components/ui/card";
 import config from "@/payload.config";
 import type { Media, Project, SportCategory } from "@/payload-types";
 import type { Locale } from "@/lib/i18n";
+import { LANDING_PROJECTS_TAG } from "@/lib/cache-tags";
 import { hasPayloadImage } from "@/lib/payload-image";
 
 export async function getProjectCards(locale: Locale): Promise<CardProject[]> {
-  noStore();
+  const getCachedProjectCards = unstable_cache(
+    async (): Promise<CardProject[]> => {
+      const payload = await getPayload({ config });
+      const result = await payload.find({
+        collection: "projects",
+        depth: 1,
+        limit: 50,
+        locale,
+        fallbackLocale: "en",
+        sort: "sortOrder",
+        where: {
+          active: {
+            equals: true,
+          },
+        },
+      });
+
+      return result.docs.flatMap((project: Project): CardProject[] => {
+        const image =
+          project.image && typeof project.image !== "number"
+            ? (project.image as Media)
+            : null;
+        const category =
+          project.category && typeof project.category !== "number"
+            ? (project.category as SportCategory)
+            : null;
+
+        if (!project.title || !project.description || !category?.label) {
+          return [];
+        }
+
+        if (!hasPayloadImage(image)) {
+          return [];
+        }
+
+        const link =
+          typeof project.link === "string" && project.link.trim()
+            ? project.link.trim()
+            : null;
+
+        return [
+          {
+            image,
+            title: project.title,
+            description: project.description,
+            link,
+            category: category.label,
+          },
+        ];
+      });
+    },
+    ["project-cards", locale],
+    {
+      tags: [LANDING_PROJECTS_TAG],
+    }
+  );
 
   try {
-    const payload = await getPayload({ config });
-    const result = await payload.find({
-      collection: "projects",
-      depth: 1,
-      limit: 50,
-      locale,
-      fallbackLocale: "en",
-      sort: "sortOrder",
-      where: {
-        active: {
-          equals: true,
-        },
-      },
-    });
-
-    return result.docs.flatMap((project: Project): CardProject[] => {
-      const image =
-        project.image && typeof project.image !== "number"
-          ? (project.image as Media)
-          : null;
-      const category =
-        project.category && typeof project.category !== "number"
-          ? (project.category as SportCategory)
-          : null;
-
-      if (!project.title || !project.description || !category?.label) {
-        return [];
-      }
-
-      if (!hasPayloadImage(image)) {
-        return [];
-      }
-
-      const link =
-        typeof project.link === "string" && project.link.trim()
-          ? project.link.trim()
-          : null;
-
-      return [
-        {
-          image,
-          title: project.title,
-          description: project.description,
-          link,
-          category: category.label,
-        },
-      ];
-    });
+    return await getCachedProjectCards();
   } catch (error) {
     console.warn("Failed to load projects from Payload:", error);
     return [];

--- a/src/lib/revalidate-group-trainings.ts
+++ b/src/lib/revalidate-group-trainings.ts
@@ -1,32 +1,8 @@
-import { revalidatePath } from "next/cache";
-import { locales } from "@/lib/i18n";
-
-type RevalidateOptions = {
-  skipRevalidate?: boolean;
-};
+import { revalidateGroupTrainingContent } from "@/lib/revalidate-site-content";
 
 export async function revalidateGroupTrainingPages(
-  options?: RevalidateOptions,
+  options?: { skipRevalidate?: boolean },
   slugs?: string[]
 ): Promise<void> {
-  if (options?.skipRevalidate) return;
-
-  try {
-    const uniqueSlugs = Array.from(
-      new Set((slugs ?? []).filter((slug): slug is string => Boolean(slug)))
-    );
-
-    revalidatePath("/");
-    for (const locale of locales) {
-      revalidatePath(`/${locale}`);
-      revalidatePath(`/${locale}/`);
-
-      for (const slug of uniqueSlugs) {
-        revalidatePath(`/${locale}/groepen/${slug}`);
-        revalidatePath(`/${locale}/groepen/${slug}/`);
-      }
-    }
-  } catch (error) {
-    console.warn("Failed to revalidate group training pages:", error);
-  }
+  return revalidateGroupTrainingContent(options, slugs);
 }

--- a/src/lib/revalidate-site-content.ts
+++ b/src/lib/revalidate-site-content.ts
@@ -1,0 +1,69 @@
+import { revalidateTag } from "next/cache";
+import {
+  getGroupTrainingDetailTag,
+  LANDING_GROUP_TRAININGS_TAG,
+  LANDING_PROJECTS_TAG,
+} from "@/lib/cache-tags";
+
+type RevalidateOptions = {
+  skipRevalidate?: boolean;
+};
+
+type RevalidateTask = () => void;
+const IMMEDIATE_EXPIRY = { expire: 0 } as const;
+
+function isUnsupportedRevalidationContext(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.message.includes("during render which is unsupported") ||
+    error.message.includes(
+      'inside a function cached with "unstable_cache(...)"'
+    )
+  );
+}
+
+function toUniqueSlugs(slugs?: string[]): string[] {
+  return [...new Set((slugs ?? []).filter(Boolean))];
+}
+
+function runRevalidation(task: RevalidateTask, warningMessage: string): void {
+  try {
+    task();
+  } catch (error) {
+    if (isUnsupportedRevalidationContext(error)) {
+      return;
+    }
+
+    console.warn(warningMessage, error);
+  }
+}
+
+export async function revalidateLandingProjectContent(
+  options?: RevalidateOptions
+): Promise<void> {
+  if (options?.skipRevalidate) return;
+
+  runRevalidation(() => {
+    revalidateTag(LANDING_PROJECTS_TAG, IMMEDIATE_EXPIRY);
+  }, "Failed to revalidate landing project content:");
+}
+
+export async function revalidateGroupTrainingContent(
+  options?: RevalidateOptions,
+  slugs?: string[]
+): Promise<void> {
+  if (options?.skipRevalidate) return;
+
+  const uniqueSlugs = toUniqueSlugs(slugs);
+
+  runRevalidation(() => {
+    revalidateTag(LANDING_GROUP_TRAININGS_TAG, IMMEDIATE_EXPIRY);
+
+    uniqueSlugs.forEach((slug) => {
+      revalidateTag(getGroupTrainingDetailTag(slug), IMMEDIATE_EXPIRY);
+    });
+  }, "Failed to revalidate group training content:");
+}


### PR DESCRIPTION
## Summary
- Add cache tag constants for landing projects, landing group trainings, and per-slug group training detail pages.
- Replace per-request Payload reads with `unstable_cache` for:
- `getProjectCards`
- `getGroupTrainingCards`
- `getPublishedGroupTraining`
- Prevent cache poisoning by handling fetch failures outside cached functions and returning safe fallbacks.
- Add centralized revalidation helpers that invalidate tags with immediate expiry after CMS writes.
- Wire Payload collection hooks to revalidate landing project content on `Projects`, `SportCategories`, and `Media` changes.
- Route existing group training revalidation through the new shared revalidation helper.

## Testing
- Not run (not requested)

## How To Test In Preview
1. Open `/en/` and `/nl/` and verify **Projects** and **Group Trainings** render with localized text and links.
2. In Payload admin, edit one Project title. Reload `/en/` and `/nl/` immediately and confirm updated title appears.
3. Edit a Sport Category label used by a visible project. Reload landing pages and confirm updated category label appears.
4. Edit alt text of media used by a visible project card image. Reload landing and confirm image `alt` reflects the change.
5. Edit one Group Training title/subtitle. Reload landing pages and confirm updated card text appears.
6. Edit that Group Training slug. Reload landing and confirm card link points to the new slug.
7. Open the new detail URL and confirm title/subtitle are updated there too.
8. Edit the linked Location name/address for that training. Reload detail page and confirm location text updates.
9. Optional: hard reload twice after each admin change to verify there is no stale-first-load behavior.
10. Confirm there are no frontend console errors related to cache/hydration during these checks.
