### PR TITLE
Update the Payload skill reference set

### DIFF
--- a/.agents/skills/payload/SKILL.md
+++ b/.agents/skills/payload/SKILL.md
@@ -50,18 +50,18 @@ pnpm dev
 ### Minimal Config
 
 ```ts
-import { buildConfig } from "payload";
-import { mongooseAdapter } from "@payloadcms/db-mongodb";
-import { lexicalEditor } from "@payloadcms/richtext-lexical";
-import path from "path";
-import { fileURLToPath } from "url";
+import { buildConfig } from 'payload'
+import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
-const filename = fileURLToPath(import.meta.url);
-const dirname = path.dirname(filename);
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
 
 export default buildConfig({
   admin: {
-    user: "users",
+    user: 'users',
     importMap: {
       baseDir: path.resolve(dirname),
     },
@@ -70,12 +70,12 @@ export default buildConfig({
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET,
   typescript: {
-    outputFile: path.resolve(dirname, "payload-types.ts"),
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
   db: mongooseAdapter({
     url: process.env.DATABASE_URL,
   }),
-});
+})
 ```
 
 ## Essential Patterns
@@ -83,22 +83,22 @@ export default buildConfig({
 ### Basic Collection
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   admin: {
-    useAsTitle: "title",
-    defaultColumns: ["title", "author", "status", "createdAt"],
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'author', 'status', 'createdAt'],
   },
   fields: [
-    { name: "title", type: "text", required: true },
-    { name: "slug", type: "text", unique: true, index: true },
-    { name: "content", type: "richText" },
-    { name: "author", type: "relationship", relationTo: "users" },
+    { name: 'title', type: 'text', required: true },
+    { name: 'slug', type: 'text', unique: true, index: true },
+    { name: 'content', type: 'richText' },
+    { name: 'author', type: 'relationship', relationTo: 'users' },
   ],
   timestamps: true,
-};
+}
 ```
 
 For more collection patterns (auth, upload, drafts, live preview), see [COLLECTIONS.md](reference/COLLECTIONS.md).
@@ -128,19 +128,19 @@ For all field types (array, blocks, point, join, virtual, conditional, etc.), se
 
 ```ts
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   hooks: {
     beforeChange: [
       async ({ data, operation }) => {
-        if (operation === "create") {
-          data.slug = slugify(data.title);
+        if (operation === 'create') {
+          data.slug = slugify(data.title)
         }
-        return data;
+        return data
       },
     ],
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 For all hook patterns, see [HOOKS.md](reference/HOOKS.md). For access control, see [ACCESS-CONTROL.md](reference/ACCESS-CONTROL.md).
@@ -148,25 +148,25 @@ For all hook patterns, see [HOOKS.md](reference/HOOKS.md). For access control, s
 ### Access Control with Type Safety
 
 ```ts
-import type { Access } from "payload";
-import type { User } from "@/payload-types";
+import type { Access } from 'payload'
+import type { User } from '@/payload-types'
 
 // Type-safe access control
 export const adminOnly: Access = ({ req }) => {
-  const user = req.user as User;
-  return user?.roles?.includes("admin") || false;
-};
+  const user = req.user as User
+  return user?.roles?.includes('admin') || false
+}
 
 // Row-level access control
 export const ownPostsOnly: Access = ({ req }) => {
-  const user = req.user as User;
-  if (!user) return false;
-  if (user.roles?.includes("admin")) return true;
+  const user = req.user as User
+  if (!user) return false
+  if (user.roles?.includes('admin')) return true
 
   return {
     author: { equals: user.id },
-  };
-};
+  }
+}
 ```
 
 ### Query Example
@@ -174,30 +174,30 @@ export const ownPostsOnly: Access = ({ req }) => {
 ```ts
 // Local API
 const posts = await payload.find({
-  collection: "posts",
+  collection: 'posts',
   where: {
-    status: { equals: "published" },
-    "author.name": { contains: "john" },
+    status: { equals: 'published' },
+    'author.name': { contains: 'john' },
   },
   depth: 2,
   limit: 10,
-  sort: "-createdAt",
-});
+  sort: '-createdAt',
+})
 
 // Query with populated relationships
 const post = await payload.findByID({
-  collection: "posts",
-  id: "123",
+  collection: 'posts',
+  id: '123',
   depth: 2, // Populates relationships (default is 2)
-});
+})
 // Returns: { author: { id: "user123", name: "John" } }
 
 // Without depth, relationships return IDs only
 const post = await payload.findByID({
-  collection: "posts",
-  id: "123",
+  collection: 'posts',
+  id: '123',
   depth: 0,
-});
+})
 // Returns: { author: "user123" }
 ```
 
@@ -236,16 +236,16 @@ export default async function Page() {
 
 ```ts
 // ✅ Valid: single string
-payload.logger.error("Something went wrong");
+payload.logger.error('Something went wrong')
 
 // ✅ Valid: object with msg and err
-payload.logger.error({ msg: "Failed to process", err: error });
+payload.logger.error({ msg: 'Failed to process', err: error })
 
 // ❌ Invalid: don't pass error as second argument
-payload.logger.error("Failed to process", error);
+payload.logger.error('Failed to process', error)
 
 // ❌ Invalid: use `err` not `error`, use `msg` not `message`
-payload.logger.error({ message: "Failed", error: error });
+payload.logger.error({ message: 'Failed', error: error })
 ```
 
 ## Security Pitfalls
@@ -257,16 +257,16 @@ payload.logger.error({ message: "Failed", error: error });
 ```ts
 // ❌ SECURITY BUG: Passes user but ignores their permissions
 await payload.find({
-  collection: "posts",
+  collection: 'posts',
   user: someUser, // Access control is BYPASSED!
-});
+})
 
 // ✅ SECURE: Actually enforces the user's permissions
 await payload.find({
-  collection: "posts",
+  collection: 'posts',
   user: someUser,
   overrideAccess: false, // REQUIRED for access control
-});
+})
 ```
 
 **When to use each:**
@@ -286,12 +286,12 @@ hooks: {
   afterChange: [
     async ({ doc, req }) => {
       await req.payload.create({
-        collection: "audit-log",
+        collection: 'audit-log',
         data: { docId: doc.id },
         // Missing req - runs in separate transaction!
-      });
+      })
     },
-  ];
+  ]
 }
 
 // ✅ ATOMIC: Same transaction
@@ -299,12 +299,12 @@ hooks: {
   afterChange: [
     async ({ doc, req }) => {
       await req.payload.create({
-        collection: "audit-log",
+        collection: 'audit-log',
         data: { docId: doc.id },
         req, // Maintains atomicity
-      });
+      })
     },
-  ];
+  ]
 }
 ```
 
@@ -320,30 +320,30 @@ hooks: {
   afterChange: [
     async ({ doc, req }) => {
       await req.payload.update({
-        collection: "posts",
+        collection: 'posts',
         id: doc.id,
         data: { views: doc.views + 1 },
         req,
-      }); // Triggers afterChange again!
+      }) // Triggers afterChange again!
     },
-  ];
+  ]
 }
 
 // ✅ SAFE: Use context flag
 hooks: {
   afterChange: [
     async ({ doc, req, context }) => {
-      if (context.skipHooks) return;
+      if (context.skipHooks) return
 
       await req.payload.update({
-        collection: "posts",
+        collection: 'posts',
         id: doc.id,
         data: { views: doc.views + 1 },
         context: { skipHooks: true },
         req,
-      });
+      })
     },
-  ];
+  ]
 }
 ```
 
@@ -377,13 +377,13 @@ src/
 // payload.config.ts
 export default buildConfig({
   typescript: {
-    outputFile: path.resolve(dirname, "payload-types.ts"),
+    outputFile: path.resolve(dirname, 'payload-types.ts'),
   },
   // ...
-});
+})
 
 // Usage
-import type { Post, User } from "@/payload-types";
+import type { Post, User } from '@/payload-types'
 ```
 
 ## Reference Documentation

--- a/.agents/skills/payload/reference/ACCESS-CONTROL-ADVANCED.md
+++ b/.agents/skills/payload/reference/ACCESS-CONTROL-ADVANCED.md
@@ -9,26 +9,26 @@ Advanced access control patterns including context-aware access, time-based rest
 Control access based on user locale for internationalized content.
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const localeSpecificAccess: Access = ({ req: { user, locale } }) => {
   // Authenticated users can access all locales
-  if (user) return true;
+  if (user) return true
 
   // Public users can only access English content
-  if (locale === "en") return true;
+  if (locale === 'en') return true
 
-  return false;
-};
+  return false
+}
 
 // Usage in collection
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   access: {
     read: localeSpecificAccess,
   },
-  fields: [{ name: "title", type: "text", localized: true }],
-};
+  fields: [{ name: 'title', type: 'text', localized: true }],
+}
 ```
 
 **Source**: `docs/access-control/overview.mdx` (req.locale argument)
@@ -38,26 +38,26 @@ export const Posts: CollectionConfig = {
 Restrict access based on device type or user agent.
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const mobileOnlyAccess: Access = ({ req: { headers } }) => {
-  const userAgent = headers?.get("user-agent") || "";
-  return /mobile|android|iphone/i.test(userAgent);
-};
+  const userAgent = headers?.get('user-agent') || ''
+  return /mobile|android|iphone/i.test(userAgent)
+}
 
 export const desktopOnlyAccess: Access = ({ req: { headers } }) => {
-  const userAgent = headers?.get("user-agent") || "";
-  return !/mobile|android|iphone/i.test(userAgent);
-};
+  const userAgent = headers?.get('user-agent') || ''
+  return !/mobile|android|iphone/i.test(userAgent)
+}
 
 // Usage
 export const MobileContent: CollectionConfig = {
-  slug: "mobile-content",
+  slug: 'mobile-content',
   access: {
     read: mobileOnlyAccess,
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 **Source**: Synthesized (headers pattern)
@@ -67,25 +67,25 @@ export const MobileContent: CollectionConfig = {
 Restrict access from specific IP addresses (requires middleware/proxy headers).
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const restrictedIpAccess = (allowedIps: string[]): Access => {
   return ({ req: { headers } }) => {
-    const ip = headers?.get("x-forwarded-for") || headers?.get("x-real-ip");
-    return allowedIps.includes(ip || "");
-  };
-};
+    const ip = headers?.get('x-forwarded-for') || headers?.get('x-real-ip')
+    return allowedIps.includes(ip || '')
+  }
+}
 
 // Usage
-const internalIps = ["192.168.1.0/24", "10.0.0.5"];
+const internalIps = ['192.168.1.0/24', '10.0.0.5']
 
 export const InternalDocs: CollectionConfig = {
-  slug: "internal-docs",
+  slug: 'internal-docs',
   access: {
     read: restrictedIpAccess(internalIps),
   },
-  fields: [{ name: "content", type: "richText" }],
-};
+  fields: [{ name: 'content', type: 'richText' }],
+}
 ```
 
 **Note**: Requires your server to pass IP address via headers (common with proxies/load balancers).
@@ -97,22 +97,22 @@ export const InternalDocs: CollectionConfig = {
 ### Today's Records Only
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const todayOnlyAccess: Access = ({ req: { user } }) => {
-  if (!user) return false;
+  if (!user) return false
 
-  const now = new Date();
-  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000);
+  const now = new Date()
+  const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000)
 
   return {
     createdAt: {
       greater_than_equal: startOfDay.toISOString(),
       less_than: endOfDay.toISOString(),
     },
-  };
-};
+  }
+}
 ```
 
 **Source**: `test/access-control/config.ts` (query constraint patterns)
@@ -120,60 +120,57 @@ export const todayOnlyAccess: Access = ({ req: { user } }) => {
 ### Recent Records (Last N Days)
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const recentRecordsAccess = (days: number): Access => {
   return ({ req: { user } }) => {
-    if (!user) return false;
-    if (user.roles?.includes("admin")) return true;
+    if (!user) return false
+    if (user.roles?.includes('admin')) return true
 
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - days);
+    const cutoff = new Date()
+    cutoff.setDate(cutoff.getDate() - days)
 
     return {
       createdAt: {
         greater_than_equal: cutoff.toISOString(),
       },
-    };
-  };
-};
+    }
+  }
+}
 
 // Usage: Users see only last 30 days, admins see all
 export const Logs: CollectionConfig = {
-  slug: "logs",
+  slug: 'logs',
   access: {
     read: recentRecordsAccess(30),
   },
-  fields: [{ name: "message", type: "text" }],
-};
+  fields: [{ name: 'message', type: 'text' }],
+}
 ```
 
 ### Scheduled Content (Publish Date Range)
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const scheduledContentAccess: Access = ({ req: { user } }) => {
   // Editors see all content
-  if (user?.roles?.includes("admin") || user?.roles?.includes("editor")) {
-    return true;
+  if (user?.roles?.includes('admin') || user?.roles?.includes('editor')) {
+    return true
   }
 
-  const now = new Date().toISOString();
+  const now = new Date().toISOString()
 
   // Public sees only content within publish window
   return {
     and: [
       { publishDate: { less_than_equal: now } },
       {
-        or: [
-          { unpublishDate: { exists: false } },
-          { unpublishDate: { greater_than: now } },
-        ],
+        or: [{ unpublishDate: { exists: false } }, { unpublishDate: { greater_than: now } }],
       },
     ],
-  };
-};
+  }
+}
 ```
 
 **Source**: Synthesized (query constraint + date patterns)
@@ -183,72 +180,72 @@ export const scheduledContentAccess: Access = ({ req: { user } }) => {
 ### Active Subscription Required
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const activeSubscriptionAccess: Access = async ({ req: { user } }) => {
-  if (!user) return false;
-  if (user.roles?.includes("admin")) return true;
+  if (!user) return false
+  if (user.roles?.includes('admin')) return true
 
   try {
     const subscription = await req.payload.findByID({
-      collection: "subscriptions",
+      collection: 'subscriptions',
       id: user.subscriptionId,
-    });
+    })
 
-    return subscription?.status === "active";
+    return subscription?.status === 'active'
   } catch {
-    return false;
+    return false
   }
-};
+}
 
 // Usage
 export const PremiumContent: CollectionConfig = {
-  slug: "premium-content",
+  slug: 'premium-content',
   access: {
     read: activeSubscriptionAccess,
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 ### Subscription Tier-Based Access
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const tierBasedAccess = (requiredTier: string): Access => {
-  const tierHierarchy = ["free", "basic", "pro", "enterprise"];
+  const tierHierarchy = ['free', 'basic', 'pro', 'enterprise']
 
   return async ({ req: { user } }) => {
-    if (!user) return false;
-    if (user.roles?.includes("admin")) return true;
+    if (!user) return false
+    if (user.roles?.includes('admin')) return true
 
     try {
       const subscription = await req.payload.findByID({
-        collection: "subscriptions",
+        collection: 'subscriptions',
         id: user.subscriptionId,
-      });
+      })
 
-      if (subscription?.status !== "active") return false;
+      if (subscription?.status !== 'active') return false
 
-      const userTierIndex = tierHierarchy.indexOf(subscription.tier);
-      const requiredTierIndex = tierHierarchy.indexOf(requiredTier);
+      const userTierIndex = tierHierarchy.indexOf(subscription.tier)
+      const requiredTierIndex = tierHierarchy.indexOf(requiredTier)
 
-      return userTierIndex >= requiredTierIndex;
+      return userTierIndex >= requiredTierIndex
     } catch {
-      return false;
+      return false
     }
-  };
-};
+  }
+}
 
 // Usage
 export const EnterpriseFeatures: CollectionConfig = {
-  slug: "enterprise-features",
+  slug: 'enterprise-features',
   access: {
-    read: tierBasedAccess("enterprise"),
+    read: tierBasedAccess('enterprise'),
   },
-  fields: [{ name: "feature", type: "text" }],
-};
+  fields: [{ name: 'feature', type: 'text' }],
+}
 ```
 
 **Source**: Synthesized (async + cross-collection pattern)
@@ -262,28 +259,28 @@ Reusable functions that generate access control configurations.
 Generate access control for specific roles.
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export function createRoleBasedAccess(roles: string[]): Access {
   return ({ req: { user } }) => {
-    if (!user) return false;
-    return roles.some((role) => user.roles?.includes(role));
-  };
+    if (!user) return false
+    return roles.some((role) => user.roles?.includes(role))
+  }
 }
 
 // Usage
-const adminOrEditor = createRoleBasedAccess(["admin", "editor"]);
-const moderatorAccess = createRoleBasedAccess(["admin", "moderator"]);
+const adminOrEditor = createRoleBasedAccess(['admin', 'editor'])
+const moderatorAccess = createRoleBasedAccess(['admin', 'moderator'])
 
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   access: {
     create: adminOrEditor,
     update: adminOrEditor,
     delete: moderatorAccess,
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 **Source**: `test/access-control/config.ts`
@@ -293,35 +290,35 @@ export const Posts: CollectionConfig = {
 Generate organization-scoped access with optional admin bypass.
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export function createOrgScopedAccess(allowAdmin = true): Access {
   return ({ req: { user } }) => {
-    if (!user) return false;
-    if (allowAdmin && user.roles?.includes("admin")) return true;
+    if (!user) return false
+    if (allowAdmin && user.roles?.includes('admin')) return true
 
     return {
       organizationId: { in: user.organizationIds || [] },
-    };
-  };
+    }
+  }
 }
 
 // Usage
-const orgScoped = createOrgScopedAccess(); // Admins bypass
-const strictOrgScoped = createOrgScopedAccess(false); // Admins also scoped
+const orgScoped = createOrgScopedAccess() // Admins bypass
+const strictOrgScoped = createOrgScopedAccess(false) // Admins also scoped
 
 export const Projects: CollectionConfig = {
-  slug: "projects",
+  slug: 'projects',
   access: {
     read: orgScoped,
     update: orgScoped,
     delete: strictOrgScoped,
   },
   fields: [
-    { name: "title", type: "text" },
-    { name: "organizationId", type: "text", required: true },
+    { name: 'title', type: 'text' },
+    { name: 'organizationId', type: 'text', required: true },
   ],
-};
+}
 ```
 
 **Source**: `test/access-control/config.ts`
@@ -331,33 +328,33 @@ export const Projects: CollectionConfig = {
 Generate team-scoped access with configurable field name.
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
-export function createTeamBasedAccess(teamField = "teamId"): Access {
+export function createTeamBasedAccess(teamField = 'teamId'): Access {
   return ({ req: { user } }) => {
-    if (!user) return false;
-    if (user.roles?.includes("admin")) return true;
+    if (!user) return false
+    if (user.roles?.includes('admin')) return true
 
     return {
       [teamField]: { in: user.teamIds || [] },
-    };
-  };
+    }
+  }
 }
 
 // Usage with custom field name
-const projectTeamAccess = createTeamBasedAccess("projectTeam");
+const projectTeamAccess = createTeamBasedAccess('projectTeam')
 
 export const Tasks: CollectionConfig = {
-  slug: "tasks",
+  slug: 'tasks',
   access: {
     read: projectTeamAccess,
     update: projectTeamAccess,
   },
   fields: [
-    { name: "title", type: "text" },
-    { name: "projectTeam", type: "text", required: true },
+    { name: 'title', type: 'text' },
+    { name: 'projectTeam', type: 'text', required: true },
   ],
-};
+}
 ```
 
 **Source**: Synthesized (org pattern variation)
@@ -367,32 +364,32 @@ export const Tasks: CollectionConfig = {
 Generate access limited to records within specified days.
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export function createTimeLimitedAccess(daysAccess: number): Access {
   return ({ req: { user } }) => {
-    if (!user) return false;
-    if (user.roles?.includes("admin")) return true;
+    if (!user) return false
+    if (user.roles?.includes('admin')) return true
 
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - daysAccess);
+    const cutoff = new Date()
+    cutoff.setDate(cutoff.getDate() - daysAccess)
 
     return {
       createdAt: {
         greater_than_equal: cutoff.toISOString(),
       },
-    };
-  };
+    }
+  }
 }
 
 // Usage: Users see 90 days, admins see all
 export const ActivityLogs: CollectionConfig = {
-  slug: "activity-logs",
+  slug: 'activity-logs',
   access: {
     read: createTimeLimitedAccess(90),
   },
-  fields: [{ name: "action", type: "text" }],
-};
+  fields: [{ name: 'action', type: 'text' }],
+}
 ```
 
 **Source**: Synthesized (time + query pattern)
@@ -404,10 +401,10 @@ Complete collection configurations for common scenarios.
 ### Basic Authenticated Collection
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const BasicCollection: CollectionConfig = {
-  slug: "basic-collection",
+  slug: 'basic-collection',
   access: {
     create: ({ req: { user } }) => Boolean(user),
     read: ({ req: { user } }) => Boolean(user),
@@ -415,10 +412,10 @@ export const BasicCollection: CollectionConfig = {
     delete: ({ req: { user } }) => Boolean(user),
   },
   fields: [
-    { name: "title", type: "text", required: true },
-    { name: "content", type: "richText" },
+    { name: 'title', type: 'text', required: true },
+    { name: 'content', type: 'richText' },
   ],
-};
+}
 ```
 
 **Source**: `docs/access-control/collections.mdx`
@@ -426,45 +423,41 @@ export const BasicCollection: CollectionConfig = {
 ### Public + Authenticated Collection
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const PublicAuthCollection: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   access: {
     // Only admins/editors can create
     create: ({ req: { user } }) => {
-      return (
-        user?.roles?.some((role) => ["admin", "editor"].includes(role)) || false
-      );
+      return user?.roles?.some((role) => ['admin', 'editor'].includes(role)) || false
     },
 
     // Authenticated users see all, public sees only published
     read: ({ req: { user } }) => {
-      if (user) return true;
-      return { _status: { equals: "published" } };
+      if (user) return true
+      return { _status: { equals: 'published' } }
     },
 
     // Only admins/editors can update
     update: ({ req: { user } }) => {
-      return (
-        user?.roles?.some((role) => ["admin", "editor"].includes(role)) || false
-      );
+      return user?.roles?.some((role) => ['admin', 'editor'].includes(role)) || false
     },
 
     // Only admins can delete
     delete: ({ req: { user } }) => {
-      return user?.roles?.includes("admin") || false;
+      return user?.roles?.includes('admin') || false
     },
   },
   versions: {
     drafts: true,
   },
   fields: [
-    { name: "title", type: "text", required: true },
-    { name: "content", type: "richText", required: true },
-    { name: "author", type: "relationship", relationTo: "users" },
+    { name: 'title', type: 'text', required: true },
+    { name: 'content', type: 'richText', required: true },
+    { name: 'author', type: 'relationship', relationTo: 'users' },
   ],
-};
+}
 ```
 
 **Source**: `templates/website/src/collections/Posts/index.ts`
@@ -472,44 +465,44 @@ export const PublicAuthCollection: CollectionConfig = {
 ### Multi-User/Self-Service Collection
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const SelfServiceCollection: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   auth: true,
   access: {
     // Admins can create users
-    create: ({ req: { user } }) => user?.roles?.includes("admin") || false,
+    create: ({ req: { user } }) => user?.roles?.includes('admin') || false,
 
     // Anyone can read user profiles
     read: () => true,
 
     // Users can update self, admins can update anyone
     update: ({ req: { user }, id }) => {
-      if (!user) return false;
-      if (user.roles?.includes("admin")) return true;
-      return user.id === id;
+      if (!user) return false
+      if (user.roles?.includes('admin')) return true
+      return user.id === id
     },
 
     // Only admins can delete
-    delete: ({ req: { user } }) => user?.roles?.includes("admin") || false,
+    delete: ({ req: { user } }) => user?.roles?.includes('admin') || false,
   },
   fields: [
-    { name: "name", type: "text", required: true },
-    { name: "email", type: "email", required: true },
+    { name: 'name', type: 'text', required: true },
+    { name: 'email', type: 'email', required: true },
     {
-      name: "roles",
-      type: "select",
+      name: 'roles',
+      type: 'select',
       hasMany: true,
-      options: ["admin", "editor", "user"],
+      options: ['admin', 'editor', 'user'],
       access: {
         // Only admins can read/update roles
-        read: ({ req: { user } }) => user?.roles?.includes("admin") || false,
-        update: ({ req: { user } }) => user?.roles?.includes("admin") || false,
+        read: ({ req: { user } }) => user?.roles?.includes('admin') || false,
+        update: ({ req: { user } }) => user?.roles?.includes('admin') || false,
       },
     },
   ],
-};
+}
 ```
 
 **Source**: `templates/website/src/collections/Users/index.ts`
@@ -520,44 +513,44 @@ export const SelfServiceCollection: CollectionConfig = {
 
 ```ts
 export const debugAccess: Access = ({ req: { user }, id }) => {
-  console.log("Access check:", {
+  console.log('Access check:', {
     userId: user?.id,
     userRoles: user?.roles,
     docId: id,
     timestamp: new Date().toISOString(),
-  });
-  return true;
-};
+  })
+  return true
+}
 ```
 
 ### Verify Arguments Availability
 
 ```ts
 export const checkArgsAccess: Access = (args) => {
-  console.log("Available arguments:", {
-    hasReq: "req" in args,
-    hasUser: args.req?.user ? "yes" : "no",
-    hasId: args.id ? "provided" : "undefined",
-    hasData: args.data ? "provided" : "undefined",
-  });
-  return true;
-};
+  console.log('Available arguments:', {
+    hasReq: 'req' in args,
+    hasUser: args.req?.user ? 'yes' : 'no',
+    hasId: args.id ? 'provided' : 'undefined',
+    hasData: args.data ? 'provided' : 'undefined',
+  })
+  return true
+}
 ```
 
 ### Measure Async Operation Timing
 
 ```ts
 export const timedAsyncAccess: Access = async ({ req }) => {
-  const start = Date.now();
+  const start = Date.now()
 
-  const result = await fetch("https://auth-service.example.com/validate", {
+  const result = await fetch('https://auth-service.example.com/validate', {
     headers: { userId: req.user?.id },
-  });
+  })
 
-  console.log(`Access check took ${Date.now() - start}ms`);
+  console.log(`Access check took ${Date.now() - start}ms`)
 
-  return result.ok;
-};
+  return result.ok
+}
 ```
 
 ### Test Access Without User
@@ -565,12 +558,12 @@ export const timedAsyncAccess: Access = async ({ req }) => {
 ```ts
 // In test/development
 const testAccess = await payload.find({
-  collection: "posts",
+  collection: 'posts',
   overrideAccess: false, // Enforce access control
   user: undefined, // Simulate no user
-});
+})
 
-console.log("Public access result:", testAccess.docs.length);
+console.log('Public access result:', testAccess.docs.length)
 ```
 
 **Source**: Synthesized (debugging best practices)
@@ -582,31 +575,22 @@ console.log("Public access result:", testAccess.docs.length);
 ```ts
 // ❌ Slow: Multiple sequential async calls
 export const slowAccess: Access = async ({ req: { user } }) => {
-  const org = await req.payload.findByID({
-    collection: "orgs",
-    id: user.orgId,
-  });
-  const team = await req.payload.findByID({
-    collection: "teams",
-    id: user.teamId,
-  });
-  const subscription = await req.payload.findByID({
-    collection: "subs",
-    id: user.subId,
-  });
+  const org = await req.payload.findByID({ collection: 'orgs', id: user.orgId })
+  const team = await req.payload.findByID({ collection: 'teams', id: user.teamId })
+  const subscription = await req.payload.findByID({ collection: 'subs', id: user.subId })
 
-  return org.active && team.active && subscription.active;
-};
+  return org.active && team.active && subscription.active
+}
 
 // ✅ Fast: Use query constraints or cache in context
 export const fastAccess: Access = ({ req: { user, context } }) => {
   // Cache expensive lookups
   if (!context.orgStatus) {
-    context.orgStatus = checkOrgStatus(user.orgId);
+    context.orgStatus = checkOrgStatus(user.orgId)
   }
 
-  return context.orgStatus;
-};
+  return context.orgStatus
+}
 ```
 
 ### Query Constraint Optimization
@@ -614,14 +598,14 @@ export const fastAccess: Access = ({ req: { user, context } }) => {
 ```ts
 // ❌ Avoid: Non-indexed fields in constraints
 export const slowQuery: Access = () => ({
-  "metadata.internalCode": { equals: "ABC123" }, // Slow if not indexed
-});
+  'metadata.internalCode': { equals: 'ABC123' }, // Slow if not indexed
+})
 
 // ✅ Better: Use indexed fields
 export const fastQuery: Access = () => ({
-  status: { equals: "active" }, // Indexed field
-  organizationId: { in: ["org1", "org2"] }, // Indexed field
-});
+  status: { equals: 'active' }, // Indexed field
+  organizationId: { in: ['org1', 'org2'] }, // Indexed field
+})
 ```
 
 ### Field Access on Large Arrays
@@ -629,43 +613,43 @@ export const fastQuery: Access = () => ({
 ```ts
 // ❌ Slow: Complex access on array fields
 const arrayField: ArrayField = {
-  name: "items",
-  type: "array",
+  name: 'items',
+  type: 'array',
   fields: [
     {
-      name: "secretData",
-      type: "text",
+      name: 'secretData',
+      type: 'text',
       access: {
         read: async ({ req }) => {
           // Async call runs for EVERY array item
-          const result = await expensiveCheck();
-          return result;
+          const result = await expensiveCheck()
+          return result
         },
       },
     },
   ],
-};
+}
 
 // ✅ Fast: Simple checks or cache result
 const optimizedArrayField: ArrayField = {
-  name: "items",
-  type: "array",
+  name: 'items',
+  type: 'array',
   fields: [
     {
-      name: "secretData",
-      type: "text",
+      name: 'secretData',
+      type: 'text',
       access: {
         read: ({ req: { user }, context }) => {
           // Cache once, reuse for all items
           if (context.canReadSecret === undefined) {
-            context.canReadSecret = user?.roles?.includes("admin");
+            context.canReadSecret = user?.roles?.includes('admin')
           }
-          return context.canReadSecret;
+          return context.canReadSecret
         },
       },
     },
   ],
-};
+}
 ```
 
 ### Avoid N+1 Queries
@@ -674,14 +658,14 @@ const optimizedArrayField: ArrayField = {
 // ❌ N+1 Problem: Query per access check
 export const n1Access: Access = async ({ req, id }) => {
   // Runs for EACH document in list
-  const doc = await req.payload.findByID({ collection: "docs", id });
-  return doc.isPublic;
-};
+  const doc = await req.payload.findByID({ collection: 'docs', id })
+  return doc.isPublic
+}
 
 // ✅ Better: Use query constraint to filter at DB level
 export const efficientAccess: Access = () => {
-  return { isPublic: { equals: true } };
-};
+  return { isPublic: { equals: true } }
+}
 ```
 
 **Performance Best Practices:**

--- a/.agents/skills/payload/reference/ACCESS-CONTROL.md
+++ b/.agents/skills/payload/reference/ACCESS-CONTROL.md
@@ -49,46 +49,46 @@ User makes request
 ### Basic Patterns
 
 ```ts
-import type { CollectionConfig, Access } from "payload";
+import type { CollectionConfig, Access } from 'payload'
 
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   access: {
     // Boolean: Only authenticated users can create
     create: ({ req: { user } }) => Boolean(user),
 
     // Query constraint: Public sees published, users see all
     read: ({ req: { user } }) => {
-      if (user) return true;
-      return { status: { equals: "published" } };
+      if (user) return true
+      return { status: { equals: 'published' } }
     },
 
     // User-specific: Admins or document owner
     update: ({ req: { user }, id }) => {
-      if (user?.roles?.includes("admin")) return true;
-      return { author: { equals: user?.id } };
+      if (user?.roles?.includes('admin')) return true
+      return { author: { equals: user?.id } }
     },
 
     // Async: Check related data
     delete: async ({ req, id }) => {
       const hasComments = await req.payload.count({
-        collection: "comments",
+        collection: 'comments',
         where: { post: { equals: id } },
-      });
-      return hasComments === 0;
+      })
+      return hasComments === 0
     },
 
     // Admin panel visibility
     admin: ({ req: { user } }) => {
-      return user?.roles?.includes("admin") || user?.roles?.includes("editor");
+      return user?.roles?.includes('admin') || user?.roles?.includes('editor')
     },
   },
   fields: [
-    { name: "title", type: "text" },
-    { name: "status", type: "select", options: ["draft", "published"] },
-    { name: "author", type: "relationship", relationTo: "users" },
+    { name: 'title', type: 'text' },
+    { name: 'status', type: 'select', options: ['draft', 'published'] },
+    { name: 'author', type: 'relationship', relationTo: 'users' },
   ],
-};
+}
 ```
 
 ### Role-Based Access Control (RBAC) Pattern
@@ -96,30 +96,30 @@ export const Posts: CollectionConfig = {
 Payload does NOT provide a roles system by default. The following is a commonly accepted pattern for implementing role-based access control in auth collections:
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const Users: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   auth: true,
   fields: [
-    { name: "name", type: "text", required: true },
-    { name: "email", type: "email", required: true },
+    { name: 'name', type: 'text', required: true },
+    { name: 'email', type: 'email', required: true },
     {
-      name: "roles",
-      type: "select",
+      name: 'roles',
+      type: 'select',
       hasMany: true,
-      options: ["admin", "editor", "user"],
-      defaultValue: ["user"],
+      options: ['admin', 'editor', 'user'],
+      defaultValue: ['user'],
       required: true,
       // Save roles to JWT for access control without database lookups
       saveToJWT: true,
       access: {
         // Only admins can update roles
-        update: ({ req: { user } }) => user?.roles?.includes("admin"),
+        update: ({ req: { user } }) => user?.roles?.includes('admin'),
       },
     },
   ],
-};
+}
 ```
 
 **Important Notes:**
@@ -133,151 +133,142 @@ export const Users: CollectionConfig = {
 **Using Roles in Access Control:**
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 // Check for specific role
 export const adminOnly: Access = ({ req: { user } }) => {
-  return user?.roles?.includes("admin");
-};
+  return user?.roles?.includes('admin')
+}
 
 // Check for multiple roles
 export const adminOrEditor: Access = ({ req: { user } }) => {
-  return Boolean(
-    user?.roles?.some((role) => ["admin", "editor"].includes(role))
-  );
-};
+  return Boolean(user?.roles?.some((role) => ['admin', 'editor'].includes(role)))
+}
 
 // Role hierarchy check
 export const hasMinimumRole: Access = ({ req: { user } }, minRole: string) => {
-  const roleHierarchy = ["user", "editor", "admin"];
-  const userHighestRole = Math.max(
-    ...(user?.roles?.map((r) => roleHierarchy.indexOf(r)) || [-1])
-  );
-  const requiredRoleIndex = roleHierarchy.indexOf(minRole);
+  const roleHierarchy = ['user', 'editor', 'admin']
+  const userHighestRole = Math.max(...(user?.roles?.map((r) => roleHierarchy.indexOf(r)) || [-1]))
+  const requiredRoleIndex = roleHierarchy.indexOf(minRole)
 
-  return userHighestRole >= requiredRoleIndex;
-};
+  return userHighestRole >= requiredRoleIndex
+}
 ```
 
 ### Reusable Access Functions
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 // Anyone (public)
-export const anyone: Access = () => true;
+export const anyone: Access = () => true
 
 // Authenticated only
-export const authenticated: Access = ({ req: { user } }) => Boolean(user);
+export const authenticated: Access = ({ req: { user } }) => Boolean(user)
 
 // Authenticated or published content
 export const authenticatedOrPublished: Access = ({ req: { user } }) => {
-  if (user) return true;
-  return { _status: { equals: "published" } };
-};
+  if (user) return true
+  return { _status: { equals: 'published' } }
+}
 
 // Admin only
 export const admins: Access = ({ req: { user } }) => {
-  return user?.roles?.includes("admin");
-};
+  return user?.roles?.includes('admin')
+}
 
 // Admin or editor
 export const adminsOrEditors: Access = ({ req: { user } }) => {
-  return Boolean(
-    user?.roles?.some((role) => ["admin", "editor"].includes(role))
-  );
-};
+  return Boolean(user?.roles?.some((role) => ['admin', 'editor'].includes(role)))
+}
 
 // Self or admin
 export const adminsOrSelf: Access = ({ req: { user } }) => {
-  if (user?.roles?.includes("admin")) return true;
-  return { id: { equals: user?.id } };
-};
+  if (user?.roles?.includes('admin')) return true
+  return { id: { equals: user?.id } }
+}
 
 // Usage
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   access: {
     create: authenticated,
     read: authenticatedOrPublished,
     update: adminsOrEditors,
     delete: admins,
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 ### Row-Level Security with Complex Queries
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 // Organization-scoped access
 export const organizationScoped: Access = ({ req: { user } }) => {
-  if (user?.roles?.includes("admin")) return true;
+  if (user?.roles?.includes('admin')) return true
 
   // Users see only their organization's data
   return {
     organization: {
       equals: user?.organization,
     },
-  };
-};
+  }
+}
 
 // Multiple conditions with AND
 export const complexAccess: Access = ({ req: { user } }) => {
   return {
     and: [
-      { status: { equals: "published" } },
-      { "author.isActive": { equals: true } },
+      { status: { equals: 'published' } },
+      { 'author.isActive': { equals: true } },
       {
-        or: [
-          { visibility: { equals: "public" } },
-          { author: { equals: user?.id } },
-        ],
+        or: [{ visibility: { equals: 'public' } }, { author: { equals: user?.id } }],
       },
     ],
-  };
-};
+  }
+}
 
 // Team-based access
 export const teamMemberAccess: Access = ({ req: { user } }) => {
-  if (!user) return false;
-  if (user.roles?.includes("admin")) return true;
+  if (!user) return false
+  if (user.roles?.includes('admin')) return true
 
   return {
-    "team.members": {
+    'team.members': {
       contains: user.id,
     },
-  };
-};
+  }
+}
 ```
 
 ### Header-Based Access (API Keys)
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 export const apiKeyAccess: Access = ({ req }) => {
-  const apiKey = req.headers.get("x-api-key");
+  const apiKey = req.headers.get('x-api-key')
 
-  if (!apiKey) return false;
+  if (!apiKey) return false
 
   // Validate against stored keys
-  return apiKey === process.env.VALID_API_KEY;
-};
+  return apiKey === process.env.VALID_API_KEY
+}
 
 // Bearer token validation
 export const bearerTokenAccess: Access = async ({ req }) => {
-  const auth = req.headers.get("authorization");
+  const auth = req.headers.get('authorization')
 
-  if (!auth?.startsWith("Bearer ")) return false;
+  if (!auth?.startsWith('Bearer ')) return false
 
-  const token = auth.slice(7);
-  const isValid = await validateToken(token);
+  const token = auth.slice(7)
+  const isValid = await validateToken(token)
 
-  return isValid;
-};
+  return isValid
+}
 ```
 
 ## Field Access Control
@@ -287,165 +278,165 @@ Field access does NOT support query constraints - only boolean returns.
 ### Basic Field Access
 
 ```ts
-import type { NumberField, FieldAccess } from "payload";
+import type { NumberField, FieldAccess } from 'payload'
 
 const salaryReadAccess: FieldAccess = ({ req: { user }, doc }) => {
   // Self can read own salary
-  if (user?.id === doc?.id) return true;
+  if (user?.id === doc?.id) return true
   // Admin can read all salaries
-  return user?.roles?.includes("admin");
-};
+  return user?.roles?.includes('admin')
+}
 
 const salaryUpdateAccess: FieldAccess = ({ req: { user } }) => {
   // Only admins can update salary
-  return user?.roles?.includes("admin");
-};
+  return user?.roles?.includes('admin')
+}
 
 const salaryField: NumberField = {
-  name: "salary",
-  type: "number",
+  name: 'salary',
+  type: 'number',
   access: {
     read: salaryReadAccess,
     update: salaryUpdateAccess,
   },
-};
+}
 ```
 
 ### Sibling Data Access
 
 ```ts
-import type { ArrayField, FieldAccess } from "payload";
+import type { ArrayField, FieldAccess } from 'payload'
 
 const contentReadAccess: FieldAccess = ({ req: { user }, siblingData }) => {
   // Authenticated users see all
-  if (user) return true;
+  if (user) return true
   // Public sees only if marked public
-  return siblingData?.isPublic === true;
-};
+  return siblingData?.isPublic === true
+}
 
 const arrayField: ArrayField = {
-  name: "sections",
-  type: "array",
+  name: 'sections',
+  type: 'array',
   fields: [
     {
-      name: "isPublic",
-      type: "checkbox",
+      name: 'isPublic',
+      type: 'checkbox',
       defaultValue: false,
     },
     {
-      name: "content",
-      type: "text",
+      name: 'content',
+      type: 'text',
       access: {
         read: contentReadAccess,
       },
     },
   ],
-};
+}
 ```
 
 ### Nested Field Access
 
 ```ts
-import type { GroupField, FieldAccess } from "payload";
+import type { GroupField, FieldAccess } from 'payload'
 
 const internalOnlyAccess: FieldAccess = ({ req: { user } }) => {
-  return user?.roles?.includes("admin") || user?.roles?.includes("internal");
-};
+  return user?.roles?.includes('admin') || user?.roles?.includes('internal')
+}
 
 const groupField: GroupField = {
-  name: "internalMetadata",
-  type: "group",
+  name: 'internalMetadata',
+  type: 'group',
   access: {
     read: internalOnlyAccess,
     update: internalOnlyAccess,
   },
   fields: [
-    { name: "internalNotes", type: "textarea" },
-    { name: "priority", type: "select", options: ["low", "medium", "high"] },
+    { name: 'internalNotes', type: 'textarea' },
+    { name: 'priority', type: 'select', options: ['low', 'medium', 'high'] },
   ],
-};
+}
 ```
 
 ### Hiding Admin Fields
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const Users: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   auth: true,
   fields: [
-    { name: "name", type: "text", required: true },
-    { name: "email", type: "email", required: true },
+    { name: 'name', type: 'text', required: true },
+    { name: 'email', type: 'email', required: true },
     {
-      name: "roles",
-      type: "select",
+      name: 'roles',
+      type: 'select',
       hasMany: true,
-      options: ["admin", "editor", "user"],
+      options: ['admin', 'editor', 'user'],
       access: {
         // Hide from UI, but still saved/queried
-        read: ({ req: { user } }) => user?.roles?.includes("admin"),
+        read: ({ req: { user } }) => user?.roles?.includes('admin'),
         // Only admins can update roles
-        update: ({ req: { user } }) => user?.roles?.includes("admin"),
+        update: ({ req: { user } }) => user?.roles?.includes('admin'),
       },
     },
   ],
-};
+}
 ```
 
 ## Global Access Control
 
 ```ts
-import type { GlobalConfig, Access } from "payload";
+import type { GlobalConfig, Access } from 'payload'
 
 const adminOnly: Access = ({ req: { user } }) => {
-  return user?.roles?.includes("admin");
-};
+  return user?.roles?.includes('admin')
+}
 
 export const SiteSettings: GlobalConfig = {
-  slug: "site-settings",
+  slug: 'site-settings',
   access: {
     read: () => true, // Anyone can read settings
     update: adminOnly, // Only admins can update
     readVersions: adminOnly, // Only admins can see version history
   },
   fields: [
-    { name: "siteName", type: "text" },
-    { name: "maintenanceMode", type: "checkbox" },
+    { name: 'siteName', type: 'text' },
+    { name: 'maintenanceMode', type: 'checkbox' },
   ],
-};
+}
 ```
 
 ## Multi-Tenant Access Control
 
 ```ts
-import type { Access, CollectionConfig } from "payload";
+import type { Access, CollectionConfig } from 'payload'
 
 // Add tenant field to user type
 interface User {
-  id: string;
-  tenantId: string;
-  roles?: string[];
+  id: string
+  tenantId: string
+  roles?: string[]
 }
 
 // Tenant-scoped access
 const tenantAccess: Access = ({ req: { user } }) => {
   // No user = no access
-  if (!user) return false;
+  if (!user) return false
 
   // Super admin sees all
-  if (user.roles?.includes("super-admin")) return true;
+  if (user.roles?.includes('super-admin')) return true
 
   // Users see only their tenant's data
   return {
     tenant: {
       equals: (user as User).tenantId,
     },
-  };
-};
+  }
+}
 
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   access: {
     create: tenantAccess,
     read: tenantAccess,
@@ -453,29 +444,29 @@ export const Posts: CollectionConfig = {
     delete: tenantAccess,
   },
   fields: [
-    { name: "title", type: "text" },
+    { name: 'title', type: 'text' },
     {
-      name: "tenant",
-      type: "text",
+      name: 'tenant',
+      type: 'text',
       required: true,
       access: {
         // Tenant field hidden from non-admins
-        update: ({ req: { user } }) => user?.roles?.includes("super-admin"),
+        update: ({ req: { user } }) => user?.roles?.includes('super-admin'),
       },
       hooks: {
         // Auto-set tenant on create
         beforeChange: [
           ({ req, operation, value }) => {
-            if (operation === "create" && !value) {
-              return (req.user as User)?.tenantId;
+            if (operation === 'create' && !value) {
+              return (req.user as User)?.tenantId
             }
-            return value;
+            return value
           },
         ],
       },
     },
   ],
-};
+}
 ```
 
 ## Auth Collection Patterns
@@ -483,10 +474,10 @@ export const Posts: CollectionConfig = {
 ### Self or Admin Pattern
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const Users: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   auth: true,
   access: {
     // Anyone can read user profiles
@@ -494,85 +485,85 @@ export const Users: CollectionConfig = {
 
     // Users can update themselves, admins can update anyone
     update: ({ req: { user }, id }) => {
-      if (user?.roles?.includes("admin")) return true;
-      return user?.id === id;
+      if (user?.roles?.includes('admin')) return true
+      return user?.id === id
     },
 
     // Only admins can delete
-    delete: ({ req: { user } }) => user?.roles?.includes("admin"),
+    delete: ({ req: { user } }) => user?.roles?.includes('admin'),
   },
   fields: [
-    { name: "name", type: "text" },
-    { name: "email", type: "email" },
+    { name: 'name', type: 'text' },
+    { name: 'email', type: 'email' },
   ],
-};
+}
 ```
 
 ### Restrict Self-Updates
 
 ```ts
-import type { CollectionConfig, FieldAccess } from "payload";
+import type { CollectionConfig, FieldAccess } from 'payload'
 
 const preventSelfRoleChange: FieldAccess = ({ req: { user }, id }) => {
   // Admins can change anyone's roles
-  if (user?.roles?.includes("admin")) return true;
+  if (user?.roles?.includes('admin')) return true
   // Users cannot change their own roles
-  if (user?.id === id) return false;
-  return false;
-};
+  if (user?.id === id) return false
+  return false
+}
 
 export const Users: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   auth: true,
   fields: [
     {
-      name: "roles",
-      type: "select",
+      name: 'roles',
+      type: 'select',
       hasMany: true,
-      options: ["admin", "editor", "user"],
+      options: ['admin', 'editor', 'user'],
       access: {
         update: preventSelfRoleChange,
       },
     },
   ],
-};
+}
 ```
 
 ## Cross-Collection Validation
 
 ```ts
-import type { Access } from "payload";
+import type { Access } from 'payload'
 
 // Check if user is a project member before allowing access
 export const projectMemberAccess: Access = async ({ req, id }) => {
-  const { user, payload } = req;
+  const { user, payload } = req
 
-  if (!user) return false;
-  if (user.roles?.includes("admin")) return true;
+  if (!user) return false
+  if (user.roles?.includes('admin')) return true
 
   // Check if document exists and user is member
   const project = await payload.findByID({
-    collection: "projects",
+    collection: 'projects',
     id: id as string,
     depth: 0,
-  });
+  })
 
-  return project.members?.includes(user.id);
-};
+  return project.members?.includes(user.id)
+}
 
 // Prevent deletion if document has dependencies
 export const preventDeleteWithDependencies: Access = async ({ req, id }) => {
-  const { payload } = req;
+  const { payload } = req
 
   const dependencyCount = await payload.count({
-    collection: "related-items",
+    collection: 'related-items',
     where: {
       parent: { equals: id },
     },
-  });
+  })
 
-  return dependencyCount === 0;
-};
+  return dependencyCount === 0
+}
 ```
 
 ## Access Control Function Arguments
@@ -580,7 +571,7 @@ export const preventDeleteWithDependencies: Access = async ({ req, id }) => {
 ### Collection Create
 
 ```ts
-create: ({ req, data }) => boolean | Where;
+create: ({ req, data }) => boolean | Where
 
 // req: PayloadRequest
 //   - req.user: Authenticated user (if any)
@@ -593,7 +584,7 @@ create: ({ req, data }) => boolean | Where;
 ### Collection Read
 
 ```ts
-read: ({ req, id }) => boolean | Where;
+read: ({ req, id }) => boolean | Where
 
 // req: PayloadRequest
 // id: Document ID being read
@@ -604,7 +595,7 @@ read: ({ req, id }) => boolean | Where;
 ### Collection Update
 
 ```ts
-update: ({ req, id, data }) => boolean | Where;
+update: ({ req, id, data }) => boolean | Where
 
 // req: PayloadRequest
 // id: Document ID being updated
@@ -624,7 +615,7 @@ delete: ({ req, id }) => boolean | Where
 
 ```ts
 access: {
-  create: ({ req, data, siblingData }) => boolean;
+  create: ({ req, data, siblingData }) => boolean
 }
 
 // req: PayloadRequest
@@ -636,7 +627,7 @@ access: {
 
 ```ts
 access: {
-  read: ({ req, id, doc, siblingData }) => boolean;
+  read: ({ req, id, doc, siblingData }) => boolean
 }
 
 // req: PayloadRequest
@@ -649,7 +640,7 @@ access: {
 
 ```ts
 access: {
-  update: ({ req, id, data, doc, siblingData }) => boolean;
+  update: ({ req, id, data, doc, siblingData }) => boolean
 }
 
 // req: PayloadRequest
@@ -666,16 +657,16 @@ access: {
    ```ts
    // ❌ WRONG: Passes user but bypasses access control (default behavior)
    await payload.find({
-     collection: "posts",
+     collection: 'posts',
      user: someUser, // User is ignored for access control!
-   });
+   })
 
    // ✅ CORRECT: Respects the user's permissions
    await payload.find({
-     collection: "posts",
+     collection: 'posts',
      user: someUser,
      overrideAccess: false, // Required to enforce access control
-   });
+   })
    ```
 
    **Why this matters**: If you pass `user` without `overrideAccess: false`, the operation runs with admin privileges regardless of the user's actual permissions. This is a common security mistake.

--- a/.agents/skills/payload/reference/ADAPTERS.md
+++ b/.agents/skills/payload/reference/ADAPTERS.md
@@ -7,19 +7,19 @@ Complete reference for database, storage, and email adapters.
 ### MongoDB
 
 ```ts
-import { mongooseAdapter } from "@payloadcms/db-mongodb";
+import { mongooseAdapter } from '@payloadcms/db-mongodb'
 
 export default buildConfig({
   db: mongooseAdapter({
     url: process.env.DATABASE_URL,
   }),
-});
+})
 ```
 
 ### Postgres
 
 ```ts
-import { postgresAdapter } from "@payloadcms/db-postgres";
+import { postgresAdapter } from '@payloadcms/db-postgres'
 
 export default buildConfig({
   db: postgresAdapter({
@@ -27,24 +27,24 @@ export default buildConfig({
       connectionString: process.env.DATABASE_URL,
     },
     push: false, // Don't auto-push schema changes
-    migrationDir: "./migrations",
+    migrationDir: './migrations',
   }),
-});
+})
 ```
 
 ### SQLite
 
 ```ts
-import { sqliteAdapter } from "@payloadcms/db-sqlite";
+import { sqliteAdapter } from '@payloadcms/db-sqlite'
 
 export default buildConfig({
   db: sqliteAdapter({
     client: {
-      url: "file:./payload.db",
+      url: 'file:./payload.db',
     },
     transactionOptions: {}, // Enable transactions (disabled by default)
   }),
-});
+})
 ```
 
 ## Transactions
@@ -52,35 +52,35 @@ export default buildConfig({
 Payload automatically uses transactions for all-or-nothing database operations. Pass `req` to include operations in the same transaction.
 
 ```ts
-import type { CollectionAfterChangeHook } from "payload";
+import type { CollectionAfterChangeHook } from 'payload'
 
 const afterChange: CollectionAfterChangeHook = async ({ req, doc }) => {
   // This will be part of the same transaction
   await req.payload.create({
     req, // Pass req to use same transaction
-    collection: "audit-log",
-    data: { action: "created", docId: doc.id },
-  });
-};
+    collection: 'audit-log',
+    data: { action: 'created', docId: doc.id },
+  })
+}
 
 // Manual transaction control
-const transactionID = await payload.db.beginTransaction();
+const transactionID = await payload.db.beginTransaction()
 try {
   await payload.create({
-    collection: "orders",
+    collection: 'orders',
     data: orderData,
     req: { transactionID },
-  });
+  })
   await payload.update({
-    collection: "inventory",
+    collection: 'inventory',
     id: itemId,
     data: { stock: newStock },
     req: { transactionID },
-  });
-  await payload.db.commitTransaction(transactionID);
+  })
+  await payload.db.commitTransaction(transactionID)
 } catch (error) {
-  await payload.db.rollbackTransaction(transactionID);
-  throw error;
+  await payload.db.rollbackTransaction(transactionID)
+  throw error
 }
 ```
 
@@ -91,53 +91,45 @@ try {
 **Critical**: When performing nested operations in hooks, always pass `req` to maintain transaction context. Failing to do so breaks atomicity and can cause partial updates.
 
 ```ts
-import type { CollectionAfterChangeHook } from "payload";
+import type { CollectionAfterChangeHook } from 'payload'
 
 // ✅ CORRECT: Thread req through nested operations
-const resaveChildren: CollectionAfterChangeHook = async ({
-  collection,
-  doc,
-  req,
-}) => {
+const resaveChildren: CollectionAfterChangeHook = async ({ collection, doc, req }) => {
   // Find children - pass req
   const children = await req.payload.find({
-    collection: "children",
+    collection: 'children',
     where: { parent: { equals: doc.id } },
     req, // Maintains transaction context
-  });
+  })
 
   // Update each child - pass req
   for (const child of children.docs) {
     await req.payload.update({
       id: child.id,
-      collection: "children",
-      data: { updatedField: "value" },
+      collection: 'children',
+      data: { updatedField: 'value' },
       req, // Same transaction as parent operation
-    });
+    })
   }
-};
+}
 
 // ❌ WRONG: Missing req breaks transaction
-const brokenHook: CollectionAfterChangeHook = async ({
-  collection,
-  doc,
-  req,
-}) => {
+const brokenHook: CollectionAfterChangeHook = async ({ collection, doc, req }) => {
   const children = await req.payload.find({
-    collection: "children",
+    collection: 'children',
     where: { parent: { equals: doc.id } },
     // Missing req - separate transaction or no transaction
-  });
+  })
 
   for (const child of children.docs) {
     await req.payload.update({
       id: child.id,
-      collection: "children",
-      data: { updatedField: "value" },
+      collection: 'children',
+      data: { updatedField: 'value' },
       // Missing req - if parent operation fails, these updates persist
-    });
+    })
   }
-};
+}
 ```
 
 **Why This Matters:**
@@ -174,7 +166,7 @@ Available storage adapters:
 ### AWS S3
 
 ```ts
-import { s3Storage } from "@payloadcms/storage-s3";
+import { s3Storage } from '@payloadcms/storage-s3'
 
 export default buildConfig({
   plugins: [
@@ -192,13 +184,13 @@ export default buildConfig({
       },
     }),
   ],
-});
+})
 ```
 
 ### Azure Blob Storage
 
 ```ts
-import { azureStorage } from "@payloadcms/storage-azure";
+import { azureStorage } from '@payloadcms/storage-azure'
 
 export default buildConfig({
   plugins: [
@@ -210,13 +202,13 @@ export default buildConfig({
       containerName: process.env.AZURE_STORAGE_CONTAINER_NAME,
     }),
   ],
-});
+})
 ```
 
 ### Google Cloud Storage
 
 ```ts
-import { gcsStorage } from "@payloadcms/storage-gcs";
+import { gcsStorage } from '@payloadcms/storage-gcs'
 
 export default buildConfig({
   plugins: [
@@ -231,13 +223,13 @@ export default buildConfig({
       },
     }),
   ],
-});
+})
 ```
 
 ### Cloudflare R2
 
 ```ts
-import { r2Storage } from "@payloadcms/storage-r2";
+import { r2Storage } from '@payloadcms/storage-r2'
 
 export default buildConfig({
   plugins: [
@@ -251,18 +243,18 @@ export default buildConfig({
           accessKeyId: process.env.R2_ACCESS_KEY_ID,
           secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
         },
-        region: "auto",
+        region: 'auto',
         endpoint: process.env.R2_ENDPOINT,
       },
     }),
   ],
-});
+})
 ```
 
 ### Vercel Blob
 
 ```ts
-import { vercelBlobStorage } from "@payloadcms/storage-vercel-blob";
+import { vercelBlobStorage } from '@payloadcms/storage-vercel-blob'
 
 export default buildConfig({
   plugins: [
@@ -273,13 +265,13 @@ export default buildConfig({
       token: process.env.BLOB_READ_WRITE_TOKEN,
     }),
   ],
-});
+})
 ```
 
 ### Uploadthing
 
 ```ts
-import { uploadthingStorage } from "@payloadcms/storage-uploadthing";
+import { uploadthingStorage } from '@payloadcms/storage-uploadthing'
 
 export default buildConfig({
   plugins: [
@@ -289,11 +281,11 @@ export default buildConfig({
       },
       options: {
         token: process.env.UPLOADTHING_TOKEN,
-        acl: "public-read",
+        acl: 'public-read',
       },
     }),
   ],
-});
+})
 ```
 
 ## Email Adapters
@@ -301,12 +293,12 @@ export default buildConfig({
 ### Nodemailer (SMTP)
 
 ```ts
-import { nodemailerAdapter } from "@payloadcms/email-nodemailer";
+import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
 
 export default buildConfig({
   email: nodemailerAdapter({
-    defaultFromAddress: "noreply@example.com",
-    defaultFromName: "My App",
+    defaultFromAddress: 'noreply@example.com',
+    defaultFromName: 'My App',
     transportOptions: {
       host: process.env.SMTP_HOST,
       port: 587,
@@ -316,19 +308,19 @@ export default buildConfig({
       },
     },
   }),
-});
+})
 ```
 
 ### Resend
 
 ```ts
-import { resendAdapter } from "@payloadcms/email-resend";
+import { resendAdapter } from '@payloadcms/email-resend'
 
 export default buildConfig({
   email: resendAdapter({
-    defaultFromAddress: "noreply@example.com",
-    defaultFromName: "My App",
+    defaultFromAddress: 'noreply@example.com',
+    defaultFromName: 'My App',
     apiKey: process.env.RESEND_API_KEY,
   }),
-});
+})
 ```

--- a/.agents/skills/payload/reference/ADVANCED.md
+++ b/.agents/skills/payload/reference/ADVANCED.md
@@ -8,74 +8,74 @@ Complete reference for authentication, jobs, custom endpoints, components, plugi
 
 ```ts
 // REST API
-const response = await fetch("/api/users/login", {
-  method: "POST",
-  headers: { "Content-Type": "application/json" },
+const response = await fetch('/api/users/login', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({
-    email: "user@example.com",
-    password: "password",
+    email: 'user@example.com',
+    password: 'password',
   }),
-});
+})
 
 // Local API
 const result = await payload.login({
-  collection: "users",
+  collection: 'users',
   data: {
-    email: "user@example.com",
-    password: "password",
+    email: 'user@example.com',
+    password: 'password',
   },
-});
+})
 ```
 
 ### Forgot Password
 
 ```ts
 await payload.forgotPassword({
-  collection: "users",
+  collection: 'users',
   data: {
-    email: "user@example.com",
+    email: 'user@example.com',
   },
-});
+})
 ```
 
 ### Custom Strategy
 
 ```ts
-import type { CollectionConfig, Strategy } from "payload";
+import type { CollectionConfig, Strategy } from 'payload'
 
 const customStrategy: Strategy = {
-  name: "custom",
+  name: 'custom',
   authenticate: async ({ payload, headers }) => {
-    const token = headers.get("authorization")?.split(" ")[1];
-    if (!token) return { user: null };
+    const token = headers.get('authorization')?.split(' ')[1]
+    if (!token) return { user: null }
 
-    const user = await verifyToken(token);
-    return { user };
+    const user = await verifyToken(token)
+    return { user }
   },
-};
+}
 
 export const Users: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   auth: {
     strategies: [customStrategy],
   },
   fields: [],
-};
+}
 ```
 
 ### API Keys
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const APIKeys: CollectionConfig = {
-  slug: "api-keys",
+  slug: 'api-keys',
   auth: {
     disableLocalStrategy: true,
     useAPIKey: true,
   },
   fields: [],
-};
+}
 ```
 
 ## Jobs Queue
@@ -85,31 +85,31 @@ Offload long-running or scheduled tasks to background workers.
 ### Tasks
 
 ```ts
-import { buildConfig } from "payload";
-import type { TaskConfig } from "payload";
+import { buildConfig } from 'payload'
+import type { TaskConfig } from 'payload'
 
 export default buildConfig({
   jobs: {
     tasks: [
       {
-        slug: "sendWelcomeEmail",
+        slug: 'sendWelcomeEmail',
         inputSchema: [
-          { name: "userEmail", type: "text", required: true },
-          { name: "userName", type: "text", required: true },
+          { name: 'userEmail', type: 'text', required: true },
+          { name: 'userName', type: 'text', required: true },
         ],
-        outputSchema: [{ name: "emailSent", type: "checkbox", required: true }],
+        outputSchema: [{ name: 'emailSent', type: 'checkbox', required: true }],
         retries: 2, // Retry up to 2 times on failure
         handler: async ({ input, req }) => {
           await sendEmail({
             to: input.userEmail,
             subject: `Welcome ${input.userName}`,
-          });
-          return { output: { emailSent: true } };
+          })
+          return { output: { emailSent: true } }
         },
-      } as TaskConfig<"sendWelcomeEmail">,
+      } as TaskConfig<'sendWelcomeEmail'>,
     ],
   },
-});
+})
 ```
 
 ### Queueing Jobs
@@ -117,13 +117,13 @@ export default buildConfig({
 ```ts
 // In a hook or endpoint
 await req.payload.jobs.queue({
-  task: "sendWelcomeEmail",
+  task: 'sendWelcomeEmail',
   input: {
-    userEmail: "user@example.com",
-    userName: "John",
+    userEmail: 'user@example.com',
+    userName: 'John',
   },
-  waitUntil: new Date("2024-12-31"), // Optional: schedule for future
-});
+  waitUntil: new Date('2024-12-31'), // Optional: schedule for future
+})
 ```
 
 ### Workflows
@@ -161,59 +161,59 @@ Add custom REST API routes to collections, globals, or root config. See [ENDPOIN
 ### Root Endpoints
 
 ```ts
-import { buildConfig } from "payload";
-import type { Endpoint } from "payload";
+import { buildConfig } from 'payload'
+import type { Endpoint } from 'payload'
 
 const helloEndpoint: Endpoint = {
-  path: "/hello",
-  method: "get",
+  path: '/hello',
+  method: 'get',
   handler: () => {
-    return Response.json({ message: "Hello!" });
+    return Response.json({ message: 'Hello!' })
   },
-};
+}
 
 const greetEndpoint: Endpoint = {
-  path: "/greet/:name",
-  method: "get",
+  path: '/greet/:name',
+  method: 'get',
   handler: (req) => {
     return Response.json({
       message: `Hello ${req.routeParams.name}!`,
-    });
+    })
   },
-};
+}
 
 export default buildConfig({
   endpoints: [helloEndpoint, greetEndpoint],
   collections: [],
-  secret: process.env.PAYLOAD_SECRET || "",
-});
+  secret: process.env.PAYLOAD_SECRET || '',
+})
 ```
 
 ### Collection Endpoints
 
 ```ts
-import type { CollectionConfig, Endpoint } from "payload";
+import type { CollectionConfig, Endpoint } from 'payload'
 
 const featuredEndpoint: Endpoint = {
-  path: "/featured",
-  method: "get",
+  path: '/featured',
+  method: 'get',
   handler: async (req) => {
     const posts = await req.payload.find({
-      collection: "posts",
+      collection: 'posts',
       where: { featured: { equals: true } },
-    });
-    return Response.json(posts);
+    })
+    return Response.json(posts)
   },
-};
+}
 
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   endpoints: [featuredEndpoint],
   fields: [
-    { name: "title", type: "text" },
-    { name: "featured", type: "checkbox" },
+    { name: 'title', type: 'text' },
+    { name: 'featured', type: 'checkbox' },
   ],
-};
+}
 ```
 
 ## Custom Components
@@ -221,24 +221,22 @@ export const Posts: CollectionConfig = {
 ### Field Component (Client)
 
 ```tsx
-"use client";
-import { useField } from "@payloadcms/ui";
-import type { TextFieldClientComponent } from "payload";
+'use client'
+import { useField } from '@payloadcms/ui'
+import type { TextFieldClientComponent } from 'payload'
 
 export const CustomField: TextFieldClientComponent = () => {
-  const { value, setValue } = useField();
+  const { value, setValue } = useField()
 
-  return (
-    <input value={value || ""} onChange={(e) => setValue(e.target.value)} />
-  );
-};
+  return <input value={value || ''} onChange={(e) => setValue(e.target.value)} />
+}
 ```
 
 ### Custom View
 
 ```tsx
-"use client";
-import { DefaultTemplate } from "@payloadcms/next/templates";
+'use client'
+import { DefaultTemplate } from '@payloadcms/next/templates'
 
 export const CustomView = () => {
   return (
@@ -246,31 +244,31 @@ export const CustomView = () => {
       <h1>Custom Dashboard</h1>
       {/* Your content */}
     </DefaultTemplate>
-  );
-};
+  )
+}
 ```
 
 ### Admin Config
 
 ```ts
-import { buildConfig } from "payload";
+import { buildConfig } from 'payload'
 
 export default buildConfig({
   admin: {
     components: {
-      beforeDashboard: ["/components/BeforeDashboard"],
-      beforeLogin: ["/components/BeforeLogin"],
+      beforeDashboard: ['/components/BeforeDashboard'],
+      beforeLogin: ['/components/BeforeLogin'],
       views: {
         custom: {
-          Component: "/views/Custom",
-          path: "/custom",
+          Component: '/views/Custom',
+          path: '/custom',
         },
       },
     },
   },
   collections: [],
-  secret: process.env.PAYLOAD_SECRET || "",
-});
+  secret: process.env.PAYLOAD_SECRET || '',
+})
 ```
 
 ## Plugins
@@ -292,31 +290,31 @@ export default buildConfig({
 ### Using Plugins
 
 ```ts
-import { buildConfig } from "payload";
-import { seoPlugin } from "@payloadcms/plugin-seo";
-import { redirectsPlugin } from "@payloadcms/plugin-redirects";
+import { buildConfig } from 'payload'
+import { seoPlugin } from '@payloadcms/plugin-seo'
+import { redirectsPlugin } from '@payloadcms/plugin-redirects'
 
 export default buildConfig({
   plugins: [
     seoPlugin({
-      collections: ["posts", "pages"],
+      collections: ['posts', 'pages'],
     }),
     redirectsPlugin({
-      collections: ["pages"],
+      collections: ['pages'],
     }),
   ],
   collections: [],
-  secret: process.env.PAYLOAD_SECRET || "",
-});
+  secret: process.env.PAYLOAD_SECRET || '',
+})
 ```
 
 ### Creating Plugins
 
 ```ts
-import type { Config } from "payload";
+import type { Config } from 'payload'
 
 interface PluginOptions {
-  enabled?: boolean;
+  enabled?: boolean
 }
 
 export const myPlugin =
@@ -326,45 +324,45 @@ export const myPlugin =
     collections: [
       ...(config.collections || []),
       {
-        slug: "plugin-collection",
-        fields: [{ name: "title", type: "text" }],
+        slug: 'plugin-collection',
+        fields: [{ name: 'title', type: 'text' }],
       },
     ],
     onInit: async (payload) => {
-      if (config.onInit) await config.onInit(payload);
+      if (config.onInit) await config.onInit(payload)
       // Plugin initialization
     },
-  });
+  })
 ```
 
 ## Localization
 
 ```ts
-import { buildConfig } from "payload";
-import type { Field, Payload } from "payload";
+import { buildConfig } from 'payload'
+import type { Field, Payload } from 'payload'
 
 export default buildConfig({
   localization: {
-    locales: ["en", "es", "de"],
-    defaultLocale: "en",
+    locales: ['en', 'es', 'de'],
+    defaultLocale: 'en',
     fallback: true,
   },
   collections: [],
-  secret: process.env.PAYLOAD_SECRET || "",
-});
+  secret: process.env.PAYLOAD_SECRET || '',
+})
 
 // Localized field
 const localizedField: TextField = {
-  name: "title",
-  type: "text",
+  name: 'title',
+  type: 'text',
   localized: true,
-};
+}
 
 // Query with locale
 const posts = await payload.find({
-  collection: "posts",
-  locale: "es",
-});
+  collection: 'posts',
+  locale: 'es',
+})
 ```
 
 ## TypeScript Type References

--- a/.agents/skills/payload/reference/COLLECTIONS.md
+++ b/.agents/skills/payload/reference/COLLECTIONS.md
@@ -5,52 +5,52 @@ Complete reference for collection configurations and patterns.
 ## Basic Collection
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   labels: {
-    singular: "Post",
-    plural: "Posts",
+    singular: 'Post',
+    plural: 'Posts',
   },
   admin: {
-    useAsTitle: "title",
-    defaultColumns: ["title", "author", "status", "createdAt"],
-    group: "Content", // Organize in admin sidebar
-    description: "Blog posts and articles",
-    listSearchableFields: ["title", "slug"],
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'author', 'status', 'createdAt'],
+    group: 'Content', // Organize in admin sidebar
+    description: 'Blog posts and articles',
+    listSearchableFields: ['title', 'slug'],
   },
   fields: [
     {
-      name: "title",
-      type: "text",
+      name: 'title',
+      type: 'text',
       required: true,
       index: true,
     },
     {
-      name: "slug",
-      type: "text",
+      name: 'slug',
+      type: 'text',
       unique: true,
       index: true,
-      admin: { position: "sidebar" },
+      admin: { position: 'sidebar' },
     },
     {
-      name: "status",
-      type: "select",
-      options: ["draft", "published"],
-      defaultValue: "draft",
+      name: 'status',
+      type: 'select',
+      options: ['draft', 'published'],
+      defaultValue: 'draft',
     },
   ],
-  defaultSort: "-createdAt",
+  defaultSort: '-createdAt',
   timestamps: true,
-};
+}
 ```
 
 ## Auth Collection
 
 ```ts
 export const Users: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   auth: {
     tokenExpiration: 7200, // 2 hours
     verify: true,
@@ -59,49 +59,49 @@ export const Users: CollectionConfig = {
     useAPIKey: true,
   },
   admin: {
-    useAsTitle: "email",
+    useAsTitle: 'email',
   },
   fields: [
     {
-      name: "roles",
-      type: "select",
+      name: 'roles',
+      type: 'select',
       hasMany: true,
-      options: ["admin", "editor", "user"],
+      options: ['admin', 'editor', 'user'],
       required: true,
-      defaultValue: ["user"],
+      defaultValue: ['user'],
       saveToJWT: true,
     },
     {
-      name: "name",
-      type: "text",
+      name: 'name',
+      type: 'text',
       required: true,
     },
   ],
-};
+}
 ```
 
 ## Upload Collection
 
 ```ts
 export const Media: CollectionConfig = {
-  slug: "media",
+  slug: 'media',
   upload: {
-    staticDir: "media",
-    mimeTypes: ["image/*"],
+    staticDir: 'media',
+    mimeTypes: ['image/*'],
     imageSizes: [
       {
-        name: "thumbnail",
+        name: 'thumbnail',
         width: 400,
         height: 300,
-        position: "centre",
+        position: 'centre',
       },
       {
-        name: "card",
+        name: 'card',
         width: 768,
         height: 1024,
       },
     ],
-    adminThumbnail: "thumbnail",
+    adminThumbnail: 'thumbnail',
     focalPoint: true,
     crop: true,
   },
@@ -110,17 +110,17 @@ export const Media: CollectionConfig = {
   },
   fields: [
     {
-      name: "alt",
-      type: "text",
+      name: 'alt',
+      type: 'text',
       required: true,
     },
     {
-      name: "caption",
-      type: "text",
+      name: 'caption',
+      type: 'text',
       localized: true,
     },
   ],
-};
+}
 ```
 
 ## Live Preview
@@ -128,31 +128,31 @@ export const Media: CollectionConfig = {
 Enable real-time content preview during editing.
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 const generatePreviewPath = ({
   slug,
   collection,
   req,
 }: {
-  slug: string;
-  collection: string;
-  req: any;
+  slug: string
+  collection: string
+  req: any
 }) => {
-  const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL;
-  return `${baseUrl}/api/preview?slug=${slug}&collection=${collection}`;
-};
+  const baseUrl = process.env.NEXT_PUBLIC_SERVER_URL
+  return `${baseUrl}/api/preview?slug=${slug}&collection=${collection}`
+}
 
 export const Pages: CollectionConfig = {
-  slug: "pages",
+  slug: 'pages',
   admin: {
-    useAsTitle: "title",
+    useAsTitle: 'title',
     // Live preview during editing
     livePreview: {
       url: ({ data, req }) =>
         generatePreviewPath({
           slug: data?.slug as string,
-          collection: "pages",
+          collection: 'pages',
           req,
         }),
     },
@@ -160,15 +160,15 @@ export const Pages: CollectionConfig = {
     preview: (data, { req }) =>
       generatePreviewPath({
         slug: data?.slug as string,
-        collection: "pages",
+        collection: 'pages',
         req,
       }),
   },
   fields: [
-    { name: "title", type: "text" },
-    { name: "slug", type: "text" },
+    { name: 'title', type: 'text' },
+    { name: 'slug', type: 'text' },
   ],
-};
+}
 ```
 
 ## Versioning & Drafts
@@ -176,28 +176,28 @@ export const Pages: CollectionConfig = {
 Payload maintains version history and supports draft/publish workflows.
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 // Basic versioning (audit log only)
 export const Users: CollectionConfig = {
-  slug: "users",
+  slug: 'users',
   versions: true, // or { maxPerDoc: 100 }
-  fields: [{ name: "name", type: "text" }],
-};
+  fields: [{ name: 'name', type: 'text' }],
+}
 
 // Drafts enabled (draft/publish workflow)
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   versions: {
     drafts: true, // Enables _status field
     maxPerDoc: 50,
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 
 // Full configuration with autosave and scheduled publish
 export const Pages: CollectionConfig = {
-  slug: "pages",
+  slug: 'pages',
   versions: {
     drafts: {
       autosave: true, // Auto-save while editing
@@ -206,8 +206,8 @@ export const Pages: CollectionConfig = {
     },
     maxPerDoc: 100, // Keep last 100 versions (0 = unlimited)
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 ### Draft API Usage
@@ -215,43 +215,43 @@ export const Pages: CollectionConfig = {
 ```ts
 // Create draft
 await payload.create({
-  collection: "posts",
-  data: { title: "Draft Post" },
+  collection: 'posts',
+  data: { title: 'Draft Post' },
   draft: true, // Saves as draft, skips required field validation
-});
+})
 
 // Update as draft
 await payload.update({
-  collection: "posts",
-  id: "123",
-  data: { title: "Updated Draft" },
+  collection: 'posts',
+  id: '123',
+  data: { title: 'Updated Draft' },
   draft: true,
-});
+})
 
 // Read with drafts (returns newest draft if available)
 const post = await payload.findByID({
-  collection: "posts",
-  id: "123",
+  collection: 'posts',
+  id: '123',
   draft: true, // Returns draft version if exists
-});
+})
 
 // Query only published (REST API)
 // GET /api/posts (returns only _status: 'published')
 
 // Access control for drafts
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   versions: { drafts: true },
   access: {
     read: ({ req: { user } }) => {
       // Public can only see published
-      if (!user) return { _status: { equals: "published" } };
+      if (!user) return { _status: { equals: 'published' } }
       // Authenticated can see all
-      return true;
+      return true
     },
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 ### Document Status
@@ -267,37 +267,37 @@ The `_status` field is auto-injected when drafts are enabled:
 Globals are single-instance documents (not collections).
 
 ```ts
-import type { GlobalConfig } from "payload";
+import type { GlobalConfig } from 'payload'
 
 export const Header: GlobalConfig = {
-  slug: "header",
-  label: "Header",
+  slug: 'header',
+  label: 'Header',
   admin: {
-    group: "Settings",
+    group: 'Settings',
   },
   fields: [
     {
-      name: "logo",
-      type: "upload",
-      relationTo: "media",
+      name: 'logo',
+      type: 'upload',
+      relationTo: 'media',
       required: true,
     },
     {
-      name: "nav",
-      type: "array",
+      name: 'nav',
+      type: 'array',
       maxRows: 8,
       fields: [
         {
-          name: "link",
-          type: "relationship",
-          relationTo: "pages",
+          name: 'link',
+          type: 'relationship',
+          relationTo: 'pages',
         },
         {
-          name: "label",
-          type: "text",
+          name: 'label',
+          type: 'text',
         },
       ],
     },
   ],
-};
+}
 ```

--- a/.agents/skills/payload/reference/ENDPOINTS.md
+++ b/.agents/skills/payload/reference/ENDPOINTS.md
@@ -38,20 +38,20 @@ Custom REST API endpoints extend Payload's auto-generated CRUD operations with c
 Custom endpoints are **not authenticated by default**. Check `req.user` to enforce authentication.
 
 ```ts
-import { APIError } from "payload";
+import { APIError } from 'payload'
 
 export const authenticatedEndpoint = {
-  path: "/protected",
-  method: "get",
+  path: '/protected',
+  method: 'get',
   handler: async (req) => {
     if (!req.user) {
-      throw new APIError("Unauthorized", 401);
+      throw new APIError('Unauthorized', 401)
     }
 
     // User is authenticated
-    return Response.json({ message: "Access granted" });
+    return Response.json({ message: 'Access granted' })
   },
-};
+}
 ```
 
 ### Using Payload Operations
@@ -60,26 +60,26 @@ Use `req.payload` for database operations with access control and hooks.
 
 ```ts
 export const getRelatedPosts = {
-  path: "/:id/related",
-  method: "get",
+  path: '/:id/related',
+  method: 'get',
   handler: async (req) => {
-    const { id } = req.routeParams;
+    const { id } = req.routeParams
 
     // Find related posts
     const posts = await req.payload.find({
-      collection: "posts",
+      collection: 'posts',
       where: {
         category: {
           equals: id,
         },
       },
       limit: 5,
-      sort: "-createdAt",
-    });
+      sort: '-createdAt',
+    })
 
-    return Response.json(posts);
+    return Response.json(posts)
   },
-};
+}
 ```
 
 ### Route Parameters
@@ -88,20 +88,20 @@ Access path parameters via `req.routeParams`.
 
 ```ts
 export const getTrackingEndpoint = {
-  path: "/:id/tracking",
-  method: "get",
+  path: '/:id/tracking',
+  method: 'get',
   handler: async (req) => {
-    const orderId = req.routeParams.id;
+    const orderId = req.routeParams.id
 
-    const tracking = await getTrackingInfo(orderId);
+    const tracking = await getTrackingInfo(orderId)
 
     if (!tracking) {
-      return Response.json({ error: "not found" }, { status: 404 });
+      return Response.json({ error: 'not found' }, { status: 404 })
     }
 
-    return Response.json(tracking);
+    return Response.json(tracking)
   },
-};
+}
 ```
 
 ### Request Body Handling
@@ -110,44 +110,44 @@ export const getTrackingEndpoint = {
 
 ```ts
 export const createEndpoint = {
-  path: "/create",
-  method: "post",
+  path: '/create',
+  method: 'post',
   handler: async (req) => {
-    const data = await req.json();
+    const data = await req.json()
 
     const result = await req.payload.create({
-      collection: "posts",
+      collection: 'posts',
       data,
-    });
+    })
 
-    return Response.json(result);
+    return Response.json(result)
   },
-};
+}
 ```
 
 **Option 2: Using helper (handles JSON + files)**
 
 ```ts
-import { addDataAndFileToRequest } from "payload";
+import { addDataAndFileToRequest } from 'payload'
 
 export const uploadEndpoint = {
-  path: "/upload",
-  method: "post",
+  path: '/upload',
+  method: 'post',
   handler: async (req) => {
-    await addDataAndFileToRequest(req);
+    await addDataAndFileToRequest(req)
 
     // req.data now contains parsed body
     // req.file contains uploaded file (if multipart)
 
     const result = await req.payload.create({
-      collection: "media",
+      collection: 'media',
       data: req.data,
       file: req.file,
-    });
+    })
 
-    return Response.json(result);
+    return Response.json(result)
   },
-};
+}
 ```
 
 ### CORS Headers
@@ -155,22 +155,22 @@ export const uploadEndpoint = {
 Use `headersWithCors` helper to apply config CORS settings.
 
 ```ts
-import { headersWithCors } from "payload";
+import { headersWithCors } from 'payload'
 
 export const corsEndpoint = {
-  path: "/public-data",
-  method: "get",
+  path: '/public-data',
+  method: 'get',
   handler: async (req) => {
-    const data = await fetchPublicData();
+    const data = await fetchPublicData()
 
     return Response.json(data, {
       headers: headersWithCors({
         headers: new Headers(),
         req,
       }),
-    });
+    })
   },
-};
+}
 ```
 
 ### Error Handling
@@ -178,22 +178,22 @@ export const corsEndpoint = {
 Throw `APIError` with status codes for proper error responses.
 
 ```ts
-import { APIError } from "payload";
+import { APIError } from 'payload'
 
 export const validateEndpoint = {
-  path: "/validate",
-  method: "post",
+  path: '/validate',
+  method: 'post',
   handler: async (req) => {
-    const data = await req.json();
+    const data = await req.json()
 
     if (!data.email) {
-      throw new APIError("Email is required", 400);
+      throw new APIError('Email is required', 400)
     }
 
     // Validation passed
-    return Response.json({ valid: true });
+    return Response.json({ valid: true })
   },
-};
+}
 ```
 
 ### Query Parameters
@@ -202,26 +202,26 @@ Extract query params from URL.
 
 ```ts
 export const searchEndpoint = {
-  path: "/search",
-  method: "get",
+  path: '/search',
+  method: 'get',
   handler: async (req) => {
-    const url = new URL(req.url);
-    const query = url.searchParams.get("q");
-    const limit = parseInt(url.searchParams.get("limit") || "10");
+    const url = new URL(req.url)
+    const query = url.searchParams.get('q')
+    const limit = parseInt(url.searchParams.get('limit') || '10')
 
     const results = await req.payload.find({
-      collection: "posts",
+      collection: 'posts',
       where: {
         title: {
           contains: query,
         },
       },
       limit,
-    });
+    })
 
-    return Response.json(results);
+    return Response.json(results)
   },
-};
+}
 ```
 
 ## Helper Functions
@@ -231,21 +231,21 @@ export const searchEndpoint = {
 Parses request body and attaches to `req.data` and `req.file`.
 
 ```ts
-import { addDataAndFileToRequest } from "payload";
+import { addDataAndFileToRequest } from 'payload'
 
 export const endpoint = {
-  path: "/process",
-  method: "post",
+  path: '/process',
+  method: 'post',
   handler: async (req) => {
-    await addDataAndFileToRequest(req);
+    await addDataAndFileToRequest(req)
 
     // req.data: parsed JSON or form data
     // req.file: uploaded file (if multipart)
 
-    console.log(req.data); // { title: 'My Post' }
-    console.log(req.file); // File object or undefined
+    console.log(req.data) // { title: 'My Post' }
+    console.log(req.file) // File object or undefined
   },
-};
+}
 ```
 
 **Handles:**
@@ -259,25 +259,25 @@ export const endpoint = {
 Extracts locale from request data and validates against config.
 
 ```ts
-import { addLocalesToRequestFromData } from "payload";
+import { addLocalesToRequestFromData } from 'payload'
 
 export const endpoint = {
-  path: "/translate",
-  method: "post",
+  path: '/translate',
+  method: 'post',
   handler: async (req) => {
-    await addLocalesToRequestFromData(req);
+    await addLocalesToRequestFromData(req)
 
     // req.locale: validated locale string
     // req.fallbackLocale: fallback locale string
 
     const result = await req.payload.find({
-      collection: "posts",
+      collection: 'posts',
       locale: req.locale,
-    });
+    })
 
-    return Response.json(result);
+    return Response.json(result)
   },
-};
+}
 ```
 
 ### headersWithCors
@@ -285,24 +285,24 @@ export const endpoint = {
 Applies CORS headers from Payload config.
 
 ```ts
-import { headersWithCors } from "payload";
+import { headersWithCors } from 'payload'
 
 export const endpoint = {
-  path: "/data",
-  method: "get",
+  path: '/data',
+  method: 'get',
   handler: async (req) => {
-    const data = { message: "Hello" };
+    const data = { message: 'Hello' }
 
     return Response.json(data, {
       headers: headersWithCors({
         headers: new Headers({
-          "Cache-Control": "public, max-age=3600",
+          'Cache-Control': 'public, max-age=3600',
         }),
         req,
       }),
-    });
+    })
   },
-};
+}
 ```
 
 ## Real-World Examples
@@ -312,60 +312,56 @@ export const endpoint = {
 From `examples/multi-tenant`:
 
 ```ts
-import { APIError, generatePayloadCookie, headersWithCors } from "payload";
+import { APIError, generatePayloadCookie, headersWithCors } from 'payload'
 
 export const externalUsersLogin = {
-  path: "/login-external",
-  method: "post",
+  path: '/login-external',
+  method: 'post',
   handler: async (req) => {
-    const { email, password, tenant } = await req.json();
+    const { email, password, tenant } = await req.json()
 
     if (!email || !password || !tenant) {
-      throw new APIError("Missing credentials", 400);
+      throw new APIError('Missing credentials', 400)
     }
 
     // Find user with tenant constraint
     const userQuery = await req.payload.find({
-      collection: "users",
+      collection: 'users',
       where: {
         and: [
           { email: { equals: email } },
           {
-            or: [
-              { tenants: { equals: tenant } },
-              { "tenants.tenant": { equals: tenant } },
-            ],
+            or: [{ tenants: { equals: tenant } }, { 'tenants.tenant': { equals: tenant } }],
           },
         ],
       },
-    });
+    })
 
     if (!userQuery.docs.length) {
-      throw new APIError("Invalid credentials", 401);
+      throw new APIError('Invalid credentials', 401)
     }
 
     // Authenticate user
     const result = await req.payload.login({
-      collection: "users",
+      collection: 'users',
       data: { email, password },
-    });
+    })
 
     return Response.json(result, {
       headers: headersWithCors({
         headers: new Headers({
-          "Set-Cookie": generatePayloadCookie({
-            collectionAuthConfig: req.payload.config.collections.find(
-              (c) => c.slug === "users"
-            ).auth,
+          'Set-Cookie': generatePayloadCookie({
+            collectionAuthConfig: req.payload.config.collections.find((c) => c.slug === 'users')
+              .auth,
             cookiePrefix: req.payload.config.cookiePrefix,
             token: result.token,
           }),
         }),
         req,
       }),
-    });
+    })
   },
-};
+}
 ```
 
 ### Webhook Handler (Stripe)
@@ -374,36 +370,32 @@ From `packages/plugin-ecommerce`:
 
 ```ts
 export const webhookEndpoint = {
-  path: "/webhooks",
-  method: "post",
+  path: '/webhooks',
+  method: 'post',
   handler: async (req) => {
-    const body = await req.text();
-    const signature = req.headers.get("stripe-signature");
+    const body = await req.text()
+    const signature = req.headers.get('stripe-signature')
 
     try {
-      const event = stripe.webhooks.constructEvent(
-        body,
-        signature,
-        webhookSecret
-      );
+      const event = stripe.webhooks.constructEvent(body, signature, webhookSecret)
 
       // Process event
       switch (event.type) {
-        case "payment_intent.succeeded":
-          await handlePaymentSuccess(req.payload, event.data.object);
-          break;
-        case "payment_intent.failed":
-          await handlePaymentFailure(req.payload, event.data.object);
-          break;
+        case 'payment_intent.succeeded':
+          await handlePaymentSuccess(req.payload, event.data.object)
+          break
+        case 'payment_intent.failed':
+          await handlePaymentFailure(req.payload, event.data.object)
+          break
       }
 
-      return Response.json({ received: true });
+      return Response.json({ received: true })
     } catch (err) {
-      req.payload.logger.error(`Webhook error: ${err.message}`);
-      return Response.json({ error: err.message }, { status: 400 });
+      req.payload.logger.error(`Webhook error: ${err.message}`)
+      return Response.json({ error: err.message }, { status: 400 })
     }
   },
-};
+}
 ```
 
 ### Data Preview Endpoint
@@ -411,26 +403,24 @@ export const webhookEndpoint = {
 From `packages/plugin-import-export`:
 
 ```ts
-import { addDataAndFileToRequest } from "payload";
+import { addDataAndFileToRequest } from 'payload'
 
 export const previewEndpoint = {
-  path: "/preview",
-  method: "post",
+  path: '/preview',
+  method: 'post',
   handler: async (req) => {
     if (!req.user) {
-      throw new APIError("Unauthorized", 401);
+      throw new APIError('Unauthorized', 401)
     }
 
-    await addDataAndFileToRequest(req);
+    await addDataAndFileToRequest(req)
 
-    const { collection, where, limit = 10 } = req.data;
+    const { collection, where, limit = 10 } = req.data
 
     // Validate collection exists
-    const collectionConfig = req.payload.config.collections.find(
-      (c) => c.slug === collection
-    );
+    const collectionConfig = req.payload.config.collections.find((c) => c.slug === collection)
     if (!collectionConfig) {
-      throw new APIError("Collection not found", 404);
+      throw new APIError('Collection not found', 404)
     }
 
     // Preview data
@@ -439,15 +429,15 @@ export const previewEndpoint = {
       where,
       limit,
       depth: 0,
-    });
+    })
 
     return Response.json({
       docs: results.docs,
       totalDocs: results.totalDocs,
       fields: collectionConfig.fields,
-    });
+    })
   },
-};
+}
 ```
 
 ### Reindex Action Endpoint
@@ -456,28 +446,24 @@ From `packages/plugin-search`:
 
 ```ts
 export const reindexEndpoint = (pluginConfig) => ({
-  path: "/reindex",
-  method: "post",
+  path: '/reindex',
+  method: 'post',
   handler: async (req) => {
     if (!req.user) {
-      throw new APIError("Unauthorized", 401);
+      throw new APIError('Unauthorized', 401)
     }
 
-    const { collection } = req.routeParams;
+    const { collection } = req.routeParams
 
     // Reindex collection
-    const result = await reindexCollection(
-      req.payload,
-      collection,
-      pluginConfig
-    );
+    const result = await reindexCollection(req.payload, collection, pluginConfig)
 
     return Response.json({
       message: `Reindexed ${result.count} documents`,
       count: result.count,
-    });
+    })
   },
-});
+})
 ```
 
 ## Endpoint Placement
@@ -487,25 +473,25 @@ export const reindexEndpoint = (pluginConfig) => ({
 Mounted at `/api/{collection-slug}/{path}`.
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const Orders: CollectionConfig = {
-  slug: "orders",
+  slug: 'orders',
   fields: [
     /* ... */
   ],
   endpoints: [
     {
-      path: "/:id/tracking",
-      method: "get",
+      path: '/:id/tracking',
+      method: 'get',
       handler: async (req) => {
         // Available at: /api/orders/:id/tracking
-        const orderId = req.routeParams.id;
-        return Response.json({ orderId });
+        const orderId = req.routeParams.id
+        return Response.json({ orderId })
       },
     },
   ],
-};
+}
 ```
 
 ### Global Endpoints
@@ -513,25 +499,25 @@ export const Orders: CollectionConfig = {
 Mounted at `/api/globals/{global-slug}/{path}`.
 
 ```ts
-import type { GlobalConfig } from "payload";
+import type { GlobalConfig } from 'payload'
 
 export const Settings: GlobalConfig = {
-  slug: "settings",
+  slug: 'settings',
   fields: [
     /* ... */
   ],
   endpoints: [
     {
-      path: "/clear-cache",
-      method: "post",
+      path: '/clear-cache',
+      method: 'post',
       handler: async (req) => {
         // Available at: /api/globals/settings/clear-cache
-        await clearCache();
-        return Response.json({ message: "Cache cleared" });
+        await clearCache()
+        return Response.json({ message: 'Cache cleared' })
       },
     },
   ],
-};
+}
 ```
 
 ## Advanced Patterns
@@ -542,21 +528,21 @@ Create reusable endpoint factories for plugins.
 
 ```ts
 export const createWebhookEndpoint = (config) => ({
-  path: "/webhook",
-  method: "post",
+  path: '/webhook',
+  method: 'post',
   handler: async (req) => {
-    const signature = req.headers.get("x-webhook-signature");
+    const signature = req.headers.get('x-webhook-signature')
 
     if (!verifySignature(signature, config.secret)) {
-      throw new APIError("Invalid signature", 401);
+      throw new APIError('Invalid signature', 401)
     }
 
-    const data = await req.json();
-    await processWebhook(req.payload, data, config);
+    const data = await req.json()
+    await processWebhook(req.payload, data, config)
 
-    return Response.json({ received: true });
+    return Response.json({ received: true })
   },
-});
+})
 ```
 
 ### Conditional Endpoints
@@ -565,29 +551,29 @@ Add endpoints based on config options.
 
 ```ts
 export const MyCollection: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   fields: [
     /* ... */
   ],
   endpoints: [
     // Always included
     {
-      path: "/public",
-      method: "get",
+      path: '/public',
+      method: 'get',
       handler: async (req) => Response.json({ data: [] }),
     },
     // Conditionally included
     ...(process.env.ENABLE_ANALYTICS
       ? [
           {
-            path: "/analytics",
-            method: "get",
+            path: '/analytics',
+            method: 'get',
             handler: async (req) => Response.json({ analytics: [] }),
           },
         ]
       : []),
   ],
-};
+}
 ```
 
 ### OpenAPI Documentation
@@ -596,35 +582,35 @@ Use `custom` property for API documentation metadata.
 
 ```ts
 export const endpoint = {
-  path: "/search",
-  method: "get",
+  path: '/search',
+  method: 'get',
   handler: async (req) => {
     // Handler implementation
   },
   custom: {
     openapi: {
-      summary: "Search posts",
+      summary: 'Search posts',
       parameters: [
         {
-          name: "q",
-          in: "query",
+          name: 'q',
+          in: 'query',
           required: true,
-          schema: { type: "string" },
+          schema: { type: 'string' },
         },
       ],
       responses: {
         200: {
-          description: "Search results",
+          description: 'Search results',
           content: {
-            "application/json": {
-              schema: { type: "array" },
+            'application/json': {
+              schema: { type: 'array' },
             },
           },
         },
       },
     },
   },
-};
+}
 ```
 
 ## Best Practices

--- a/.agents/skills/payload/reference/FIELD-TYPE-GUARDS.md
+++ b/.agents/skills/payload/reference/FIELD-TYPE-GUARDS.md
@@ -9,16 +9,16 @@ Complete reference with detailed examples and patterns. See [FIELDS.md](FIELDS.m
 Checks if field contains nested fields (group, array, row, or collapsible).
 
 ```ts
-import type { Field } from "payload";
-import { fieldHasSubFields } from "payload";
+import type { Field } from 'payload'
+import { fieldHasSubFields } from 'payload'
 
 function traverseFields(fields: Field[]): void {
   fields.forEach((field) => {
     if (fieldHasSubFields(field)) {
       // Safe to access field.fields
-      traverseFields(field.fields);
+      traverseFields(field.fields)
     }
-  });
+  })
 }
 ```
 
@@ -43,12 +43,12 @@ if (fieldHasSubFields(field) && !fieldIsArrayType(field)) {
 Checks if field type is `'array'`.
 
 ```ts
-import { fieldIsArrayType } from "payload";
+import { fieldIsArrayType } from 'payload'
 
 if (fieldIsArrayType(field)) {
   // field.type === 'array'
-  console.log(`Min rows: ${field.minRows}`);
-  console.log(`Max rows: ${field.maxRows}`);
+  console.log(`Min rows: ${field.minRows}`)
+  console.log(`Max rows: ${field.maxRows}`)
 }
 ```
 
@@ -65,13 +65,13 @@ fieldIsArrayType<TField extends ClientField | Field>(
 Checks if field type is `'blocks'`.
 
 ```ts
-import { fieldIsBlockType } from "payload";
+import { fieldIsBlockType } from 'payload'
 
 if (fieldIsBlockType(field)) {
   // field.type === 'blocks'
   field.blocks.forEach((block) => {
-    console.log(`Block: ${block.slug}`);
-  });
+    console.log(`Block: ${block.slug}`)
+  })
 }
 ```
 
@@ -98,11 +98,11 @@ if (fieldIsArrayType(field)) {
 Checks if field type is `'group'`.
 
 ```ts
-import { fieldIsGroupType } from "payload";
+import { fieldIsGroupType } from 'payload'
 
 if (fieldIsGroupType(field)) {
   // field.type === 'group'
-  console.log(`Interface: ${field.interfaceName}`);
+  console.log(`Interface: ${field.interfaceName}`)
 }
 ```
 
@@ -121,13 +121,13 @@ fieldIsGroupType<TField extends ClientField | Field>(
 Checks if field can have multiple values (select, relationship, or upload with `hasMany`).
 
 ```ts
-import { fieldSupportsMany } from "payload";
+import { fieldSupportsMany } from 'payload'
 
 if (fieldSupportsMany(field)) {
   // field.type is 'select' | 'relationship' | 'upload'
   // Safe to check field.hasMany
   if (field.hasMany) {
-    console.log("Field accepts multiple values");
+    console.log('Field accepts multiple values')
   }
 }
 ```
@@ -145,12 +145,12 @@ fieldSupportsMany<TField extends ClientField | Field>(
 Checks if field is relationship/upload/join with numeric `maxDepth` property.
 
 ```ts
-import { fieldHasMaxDepth } from "payload";
+import { fieldHasMaxDepth } from 'payload'
 
 if (fieldHasMaxDepth(field)) {
   // field.type is 'upload' | 'relationship' | 'join'
   // AND field.maxDepth is number
-  const remainingDepth = field.maxDepth - currentDepth;
+  const remainingDepth = field.maxDepth - currentDepth
 }
 ```
 
@@ -167,7 +167,7 @@ fieldHasMaxDepth<TField extends ClientField | Field>(
 Checks if field needs localization handling (accounts for parent localization).
 
 ```ts
-import { fieldShouldBeLocalized } from "payload";
+import { fieldShouldBeLocalized } from 'payload'
 
 function processField(field: Field, parentIsLocalized: boolean) {
   if (fieldShouldBeLocalized({ field, parentIsLocalized })) {
@@ -200,13 +200,13 @@ if (fieldShouldBeLocalized({ field, parentIsLocalized: false })) {
 Checks if field is virtual (computed or virtual relationship).
 
 ```ts
-import { fieldIsVirtual } from "payload";
+import { fieldIsVirtual } from 'payload'
 
 if (fieldIsVirtual(field)) {
   // field.virtual is truthy
-  if (typeof field.virtual === "string") {
+  if (typeof field.virtual === 'string') {
     // Virtual relationship path
-    console.log(`Virtual path: ${field.virtual}`);
+    console.log(`Virtual path: ${field.virtual}`)
   } else {
     // Computed virtual field (uses hooks)
   }
@@ -226,15 +226,15 @@ fieldIsVirtual(field: Field | Tab): boolean
 **Most commonly used guard.** Checks if field stores data (has name and is not UI-only).
 
 ```ts
-import { fieldAffectsData } from "payload";
+import { fieldAffectsData } from 'payload'
 
 function generateSchema(fields: Field[]) {
   fields.forEach((field) => {
     if (fieldAffectsData(field)) {
       // Safe to access field.name
-      schema[field.name] = getFieldType(field);
+      schema[field.name] = getFieldType(field)
     }
-  });
+  })
 }
 ```
 
@@ -249,7 +249,7 @@ fieldAffectsData<TField extends ClientField | Field | TabAsField | TabAsFieldCli
 **Pattern - Data Fields Only:**
 
 ```ts
-const dataFields = fields.filter(fieldAffectsData);
+const dataFields = fields.filter(fieldAffectsData)
 ```
 
 ### fieldIsPresentationalOnly
@@ -257,12 +257,12 @@ const dataFields = fields.filter(fieldAffectsData);
 Checks if field is UI-only (type `'ui'`).
 
 ```ts
-import { fieldIsPresentationalOnly } from "payload";
+import { fieldIsPresentationalOnly } from 'payload'
 
 if (fieldIsPresentationalOnly(field)) {
   // field.type === 'ui'
   // Skip in data operations, GraphQL schema, etc.
-  return;
+  return
 }
 ```
 
@@ -279,7 +279,7 @@ fieldIsPresentationalOnly<TField extends ClientField | Field | TabAsField | TabA
 Checks if field name is exactly `'id'`.
 
 ```ts
-import { fieldIsID } from "payload";
+import { fieldIsID } from 'payload'
 
 if (fieldIsID(field)) {
   // field.name === 'id'
@@ -300,9 +300,9 @@ fieldIsID<TField extends ClientField | Field>(
 Checks if field is hidden or admin-disabled.
 
 ```ts
-import { fieldIsHiddenOrDisabled } from "payload";
+import { fieldIsHiddenOrDisabled } from 'payload'
 
-const visibleFields = fields.filter((field) => !fieldIsHiddenOrDisabled(field));
+const visibleFields = fields.filter((field) => !fieldIsHiddenOrDisabled(field))
 ```
 
 **Signature:**
@@ -320,17 +320,17 @@ fieldIsHiddenOrDisabled<TField extends ClientField | Field | TabAsField | TabAsF
 Checks if field is positioned in sidebar.
 
 ```ts
-import { fieldIsSidebar } from "payload";
+import { fieldIsSidebar } from 'payload'
 
 const [mainFields, sidebarFields] = fields.reduce(
   ([main, sidebar], field) => {
     if (fieldIsSidebar(field)) {
-      return [main, [...sidebar, field]];
+      return [main, [...sidebar, field]]
     }
-    return [[...main, field], sidebar];
+    return [[...main, field], sidebar]
   },
-  [[], []]
-);
+  [[], []],
+)
 ```
 
 **Signature:**
@@ -348,15 +348,15 @@ fieldIsSidebar<TField extends ClientField | Field | TabAsField | TabAsFieldClien
 Checks if tab is named (stores data under tab name).
 
 ```ts
-import { tabHasName } from "payload";
+import { tabHasName } from 'payload'
 
 tabs.forEach((tab) => {
   if (tabHasName(tab)) {
     // tab.name exists
-    dataPath.push(tab.name);
+    dataPath.push(tab.name)
   }
   // Process tab.fields
-});
+})
 ```
 
 **Signature:**
@@ -372,11 +372,11 @@ tabHasName<TField extends ClientTab | Tab>(
 Checks if group is named (stores data under group name).
 
 ```ts
-import { groupHasName } from "payload";
+import { groupHasName } from 'payload'
 
 if (groupHasName(group)) {
   // group.name exists
-  return data[group.name];
+  return data[group.name]
 }
 ```
 
@@ -393,15 +393,15 @@ groupHasName(group: Partial<NamedGroupFieldClient>): group is NamedGroupFieldCli
 Checks if option is object format `{label, value}` vs string.
 
 ```ts
-import { optionIsObject } from "payload";
+import { optionIsObject } from 'payload'
 
 field.options.forEach((option) => {
   if (optionIsObject(option)) {
-    console.log(`${option.label}: ${option.value}`);
+    console.log(`${option.label}: ${option.value}`)
   } else {
-    console.log(option); // string value
+    console.log(option) // string value
   }
-});
+})
 ```
 
 **Signature:**
@@ -415,11 +415,11 @@ optionIsObject(option: Option): option is OptionObject
 Checks if entire options array contains objects.
 
 ```ts
-import { optionsAreObjects } from "payload";
+import { optionsAreObjects } from 'payload'
 
 if (optionsAreObjects(field.options)) {
   // All options are OptionObject[]
-  const labels = field.options.map((opt) => opt.label);
+  const labels = field.options.map((opt) => opt.label)
 }
 ```
 
@@ -434,11 +434,11 @@ optionsAreObjects(options: Option[]): options is OptionObject[]
 Checks if option is string value (not object).
 
 ```ts
-import { optionIsValue } from "payload";
+import { optionIsValue } from 'payload'
 
 if (optionIsValue(option)) {
   // option is string
-  const value = option;
+  const value = option
 }
 ```
 
@@ -453,12 +453,12 @@ optionIsValue(option: Option): option is string
 Checks if relationship value is polymorphic format `{relationTo, value}`.
 
 ```ts
-import { valueIsValueWithRelation } from "payload";
+import { valueIsValueWithRelation } from 'payload'
 
 if (valueIsValueWithRelation(fieldValue)) {
   // fieldValue.relationTo exists
   // fieldValue.value exists
-  console.log(`Related to ${fieldValue.relationTo}: ${fieldValue.value}`);
+  console.log(`Related to ${fieldValue.relationTo}: ${fieldValue.value}`)
 }
 ```
 
@@ -473,42 +473,36 @@ valueIsValueWithRelation(value: unknown): value is ValueWithRelation
 ### Recursive Field Traversal
 
 ```ts
-import { fieldAffectsData, fieldHasSubFields } from "payload";
+import { fieldAffectsData, fieldHasSubFields } from 'payload'
 
 function traverseFields(fields: Field[], callback: (field: Field) => void) {
   fields.forEach((field) => {
     if (fieldAffectsData(field)) {
-      callback(field);
+      callback(field)
     }
 
     if (fieldHasSubFields(field)) {
-      traverseFields(field.fields, callback);
+      traverseFields(field.fields, callback)
     }
-  });
+  })
 }
 ```
 
 ### Filter Data-Bearing Fields
 
 ```ts
-import {
-  fieldAffectsData,
-  fieldIsPresentationalOnly,
-  fieldIsHiddenOrDisabled,
-} from "payload";
+import { fieldAffectsData, fieldIsPresentationalOnly, fieldIsHiddenOrDisabled } from 'payload'
 
 const dataFields = fields.filter(
   (field) =>
-    fieldAffectsData(field) &&
-    !fieldIsPresentationalOnly(field) &&
-    !fieldIsHiddenOrDisabled(field)
-);
+    fieldAffectsData(field) && !fieldIsPresentationalOnly(field) && !fieldIsHiddenOrDisabled(field),
+)
 ```
 
 ### Container Type Switching
 
 ```ts
-import { fieldIsArrayType, fieldIsBlockType, fieldHasSubFields } from "payload";
+import { fieldIsArrayType, fieldIsBlockType, fieldHasSubFields } from 'payload'
 
 if (fieldIsArrayType(field)) {
   // Handle array-specific logic
@@ -522,18 +516,18 @@ if (fieldIsArrayType(field)) {
 ### Safe Property Access
 
 ```ts
-import { fieldSupportsMany, fieldHasMaxDepth } from "payload";
+import { fieldSupportsMany, fieldHasMaxDepth } from 'payload'
 
 // Without guard - TypeScript error
 // if (field.hasMany) { /* ... */ }
 
 // With guard - safe access
 if (fieldSupportsMany(field) && field.hasMany) {
-  console.log("Multiple values supported");
+  console.log('Multiple values supported')
 }
 
 if (fieldHasMaxDepth(field)) {
-  const depth = field.maxDepth; // TypeScript knows this is number
+  const depth = field.maxDepth // TypeScript knows this is number
 }
 ```
 
@@ -542,8 +536,8 @@ if (fieldHasMaxDepth(field)) {
 All guards preserve the original type constraint:
 
 ```ts
-import type { ClientField, Field } from "payload";
-import { fieldHasSubFields } from "payload";
+import type { ClientField, Field } from 'payload'
+import { fieldHasSubFields } from 'payload'
 
 function processServerField(field: Field) {
   if (fieldHasSubFields(field)) {

--- a/.agents/skills/payload/reference/FIELDS.md
+++ b/.agents/skills/payload/reference/FIELDS.md
@@ -5,25 +5,25 @@ Complete reference for all Payload field types with examples.
 ## Text Field
 
 ```ts
-import type { TextField } from "payload";
+import type { TextField } from 'payload'
 
 const textField: TextField = {
-  name: "title",
-  type: "text",
+  name: 'title',
+  type: 'text',
   required: true,
   unique: true,
   minLength: 5,
   maxLength: 100,
   index: true,
   localized: true,
-  defaultValue: "Default Title",
-  validate: (value) => Boolean(value) || "Required",
+  defaultValue: 'Default Title',
+  validate: (value) => Boolean(value) || 'Required',
   admin: {
-    placeholder: "Enter title...",
-    position: "sidebar",
+    placeholder: 'Enter title...',
+    position: 'sidebar',
     condition: (data) => data.showTitle === true,
   },
-};
+}
 ```
 
 ### Slug Field Helper
@@ -31,52 +31,52 @@ const textField: TextField = {
 Built-in helper for auto-generating slugs:
 
 ```ts
-import { slugField } from "payload";
-import type { CollectionConfig } from "payload";
+import { slugField } from 'payload'
+import type { CollectionConfig } from 'payload'
 
 export const Pages: CollectionConfig = {
-  slug: "pages",
+  slug: 'pages',
   fields: [
-    { name: "title", type: "text", required: true },
+    { name: 'title', type: 'text', required: true },
     slugField({
-      name: "slug", // defaults to 'slug'
-      useAsSlug: "title", // defaults to 'title'
-      checkboxName: "generateSlug", // defaults to 'generateSlug'
+      name: 'slug', // defaults to 'slug'
+      useAsSlug: 'title', // defaults to 'title'
+      checkboxName: 'generateSlug', // defaults to 'generateSlug'
       localized: true,
       required: true,
       overrides: (defaultField) => {
         // Customize the generated fields if needed
-        return defaultField;
+        return defaultField
       },
     }),
   ],
-};
+}
 ```
 
 ## Rich Text (Lexical)
 
 ```ts
-import type { RichTextField } from "payload";
-import { lexicalEditor } from "@payloadcms/richtext-lexical";
-import { HeadingFeature, LinkFeature } from "@payloadcms/richtext-lexical";
+import type { RichTextField } from 'payload'
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+import { HeadingFeature, LinkFeature } from '@payloadcms/richtext-lexical'
 
 const richTextField: RichTextField = {
-  name: "content",
-  type: "richText",
+  name: 'content',
+  type: 'richText',
   required: true,
   localized: true,
   editor: lexicalEditor({
     features: ({ defaultFeatures }) => [
       ...defaultFeatures,
       HeadingFeature({
-        enabledHeadingSizes: ["h1", "h2", "h3"],
+        enabledHeadingSizes: ['h1', 'h2', 'h3'],
       }),
       LinkFeature({
-        enabledCollections: ["posts", "pages"],
+        enabledCollections: ['posts', 'pages'],
       }),
     ],
   }),
-};
+}
 ```
 
 ### Advanced Lexical Configuration
@@ -95,7 +95,7 @@ import {
   UnderlineFeature,
   UnorderedListFeature,
   lexicalEditor,
-} from "@payloadcms/richtext-lexical";
+} from '@payloadcms/richtext-lexical'
 
 // Global editor config with full features
 export default buildConfig({
@@ -108,196 +108,196 @@ export default buildConfig({
         OrderedListFeature(),
         UnorderedListFeature(),
         LinkFeature({
-          enabledCollections: ["pages"],
+          enabledCollections: ['pages'],
           fields: ({ defaultFields }) => {
             const defaultFieldsWithoutUrl = defaultFields.filter((field) => {
-              if ("name" in field && field.name === "url") return false;
-              return true;
-            });
+              if ('name' in field && field.name === 'url') return false
+              return true
+            })
 
             return [
               ...defaultFieldsWithoutUrl,
               {
-                name: "url",
-                type: "text",
+                name: 'url',
+                type: 'text',
                 admin: {
-                  condition: ({ linkType }) => linkType !== "internal",
+                  condition: ({ linkType }) => linkType !== 'internal',
                 },
-                label: ({ t }) => t("fields:enterURL"),
+                label: ({ t }) => t('fields:enterURL'),
                 required: true,
               },
-            ];
+            ]
           },
         }),
         IndentFeature(),
         EXPERIMENTAL_TableFeature(),
-      ];
+      ]
     },
   }),
-});
+})
 
 // Field-specific editor with custom toolbar
 const richTextWithToolbars: RichTextField = {
-  name: "richText",
-  type: "richText",
+  name: 'richText',
+  type: 'richText',
   editor: lexicalEditor({
     features: ({ rootFeatures }) => {
       return [
         ...rootFeatures,
-        HeadingFeature({ enabledHeadingSizes: ["h2", "h3", "h4"] }),
+        HeadingFeature({ enabledHeadingSizes: ['h2', 'h3', 'h4'] }),
         FixedToolbarFeature(),
         InlineToolbarFeature(),
-      ];
+      ]
     },
   }),
   label: false,
-};
+}
 ```
 
 ## Relationship
 
 ```ts
-import type { RelationshipField } from "payload";
+import type { RelationshipField } from 'payload'
 
 // Single relationship
 const singleRelationship: RelationshipField = {
-  name: "author",
-  type: "relationship",
-  relationTo: "users",
+  name: 'author',
+  type: 'relationship',
+  relationTo: 'users',
   required: true,
   maxDepth: 2,
-};
+}
 
 // Multiple relationships (hasMany)
 const multipleRelationship: RelationshipField = {
-  name: "categories",
-  type: "relationship",
-  relationTo: "categories",
+  name: 'categories',
+  type: 'relationship',
+  relationTo: 'categories',
   hasMany: true,
   filterOptions: {
     active: { equals: true },
   },
-};
+}
 
 // Polymorphic relationship
 const polymorphicRelationship: PolymorphicRelationshipField = {
-  name: "relatedContent",
-  type: "relationship",
-  relationTo: ["posts", "pages"],
+  name: 'relatedContent',
+  type: 'relationship',
+  relationTo: ['posts', 'pages'],
   hasMany: true,
-};
+}
 ```
 
 ## Array
 
 ```ts
-import type { ArrayField } from "payload";
+import type { ArrayField } from 'payload'
 
 const arrayField: ArrayField = {
-  name: "slides",
-  type: "array",
+  name: 'slides',
+  type: 'array',
   minRows: 2,
   maxRows: 10,
   labels: {
-    singular: "Slide",
-    plural: "Slides",
+    singular: 'Slide',
+    plural: 'Slides',
   },
   fields: [
     {
-      name: "title",
-      type: "text",
+      name: 'title',
+      type: 'text',
       required: true,
     },
     {
-      name: "image",
-      type: "upload",
-      relationTo: "media",
+      name: 'image',
+      type: 'upload',
+      relationTo: 'media',
     },
   ],
   admin: {
     initCollapsed: true,
   },
-};
+}
 ```
 
 ## Blocks
 
 ```ts
-import type { BlocksField, Block } from "payload";
+import type { BlocksField, Block } from 'payload'
 
 const HeroBlock: Block = {
-  slug: "hero",
-  interfaceName: "HeroBlock",
+  slug: 'hero',
+  interfaceName: 'HeroBlock',
   fields: [
     {
-      name: "heading",
-      type: "text",
+      name: 'heading',
+      type: 'text',
       required: true,
     },
     {
-      name: "background",
-      type: "upload",
-      relationTo: "media",
+      name: 'background',
+      type: 'upload',
+      relationTo: 'media',
     },
   ],
-};
+}
 
 const ContentBlock: Block = {
-  slug: "content",
+  slug: 'content',
   fields: [
     {
-      name: "text",
-      type: "richText",
+      name: 'text',
+      type: 'richText',
     },
   ],
-};
+}
 
 const blocksField: BlocksField = {
-  name: "layout",
-  type: "blocks",
+  name: 'layout',
+  type: 'blocks',
   blocks: [HeroBlock, ContentBlock],
-};
+}
 ```
 
 ## Select
 
 ```ts
-import type { SelectField } from "payload";
+import type { SelectField } from 'payload'
 
 const selectField: SelectField = {
-  name: "status",
-  type: "select",
+  name: 'status',
+  type: 'select',
   options: [
-    { label: "Draft", value: "draft" },
-    { label: "Published", value: "published" },
+    { label: 'Draft', value: 'draft' },
+    { label: 'Published', value: 'published' },
   ],
-  defaultValue: "draft",
+  defaultValue: 'draft',
   required: true,
-};
+}
 
 // Multiple select
 const multiSelectField: SelectField = {
-  name: "tags",
-  type: "select",
+  name: 'tags',
+  type: 'select',
   hasMany: true,
-  options: ["tech", "news", "sports"],
-};
+  options: ['tech', 'news', 'sports'],
+}
 ```
 
 ## Upload
 
 ```ts
-import type { UploadField } from "payload";
+import type { UploadField } from 'payload'
 
 const uploadField: UploadField = {
-  name: "featuredImage",
-  type: "upload",
-  relationTo: "media",
+  name: 'featuredImage',
+  type: 'upload',
+  relationTo: 'media',
   required: true,
   filterOptions: {
-    mimeType: { contains: "image" },
+    mimeType: { contains: 'image' },
   },
-};
+}
 ```
 
 ## Point (Geolocation)
@@ -305,14 +305,14 @@ const uploadField: UploadField = {
 Point fields store geographic coordinates with automatic 2dsphere indexing for geospatial queries.
 
 ```ts
-import type { PointField } from "payload";
+import type { PointField } from 'payload'
 
 const locationField: PointField = {
-  name: "location",
-  type: "point",
-  label: "Location",
+  name: 'location',
+  type: 'point',
+  label: 'Location',
   required: true,
-};
+}
 
 // Returns [longitude, latitude]
 // Example: [-122.4194, 37.7749] for San Francisco
@@ -323,7 +323,7 @@ const locationField: PointField = {
 ```ts
 // Query by distance (sorted by nearest first)
 const nearbyLocations = await payload.find({
-  collection: "stores",
+  collection: 'stores',
   where: {
     location: {
       near: [10, 20], // [longitude, latitude]
@@ -331,7 +331,7 @@ const nearbyLocations = await payload.find({
       minDistance: 1000,
     },
   },
-});
+})
 
 // Query within polygon area
 const polygon: Point[] = [
@@ -340,32 +340,32 @@ const polygon: Point[] = [
   [11.0, 21.0], // top-right
   [11.0, 19.0], // bottom-right
   [9.0, 19.0], // closing point
-];
+]
 
 const withinArea = await payload.find({
-  collection: "stores",
+  collection: 'stores',
   where: {
     location: {
       within: {
-        type: "Polygon",
+        type: 'Polygon',
         coordinates: [polygon],
       },
     },
   },
-});
+})
 
 // Query intersecting area
 const intersecting = await payload.find({
-  collection: "stores",
+  collection: 'stores',
   where: {
     location: {
       intersects: {
-        type: "Polygon",
+        type: 'Polygon',
         coordinates: [polygon],
       },
     },
   },
-});
+})
 ```
 
 **Note**: Point fields are not supported in SQLite.
@@ -375,95 +375,92 @@ const intersecting = await payload.find({
 Join fields create reverse relationships, allowing you to access related documents from the "other side" of a relationship.
 
 ```ts
-import type { JoinField } from "payload";
+import type { JoinField } from 'payload'
 
 // From Users collection - show user's orders
 const ordersJoinField: JoinField = {
-  name: "orders",
-  type: "join",
-  collection: "orders",
-  on: "customer", // The field in 'orders' that references this user
+  name: 'orders',
+  type: 'join',
+  collection: 'orders',
+  on: 'customer', // The field in 'orders' that references this user
   admin: {
     allowCreate: false,
-    defaultColumns: ["id", "createdAt", "total", "currency", "items"],
+    defaultColumns: ['id', 'createdAt', 'total', 'currency', 'items'],
   },
-};
+}
 
 // From Users collection - show user's cart
 const cartJoinField: JoinField = {
-  name: "cart",
-  type: "join",
-  collection: "carts",
-  on: "customer",
+  name: 'cart',
+  type: 'join',
+  collection: 'carts',
+  on: 'customer',
   admin: {
     allowCreate: false,
-    defaultColumns: ["id", "createdAt", "total", "currency"],
+    defaultColumns: ['id', 'createdAt', 'total', 'currency'],
   },
-};
+}
 ```
 
 ## Virtual Fields
 
 ```ts
-import type { TextField } from "payload";
+import type { TextField } from 'payload'
 
 // Computed from siblings
 const computedVirtualField: TextField = {
-  name: "fullName",
-  type: "text",
+  name: 'fullName',
+  type: 'text',
   virtual: true,
   hooks: {
-    afterRead: [
-      ({ siblingData }) => `${siblingData.firstName} ${siblingData.lastName}`,
-    ],
+    afterRead: [({ siblingData }) => `${siblingData.firstName} ${siblingData.lastName}`],
   },
-};
+}
 
 // From relationship path
 const pathVirtualField: TextField = {
-  name: "authorName",
-  type: "text",
-  virtual: "author.name",
-};
+  name: 'authorName',
+  type: 'text',
+  virtual: 'author.name',
+}
 ```
 
 ## Conditional Fields
 
 ```ts
-import type { UploadField, CheckboxField } from "payload";
+import type { UploadField, CheckboxField } from 'payload'
 
 // Simple boolean condition
 const enableFeatureField: CheckboxField = {
-  name: "enableFeature",
-  type: "checkbox",
-};
+  name: 'enableFeature',
+  type: 'checkbox',
+}
 
 const conditionalField: TextField = {
-  name: "featureText",
-  type: "text",
+  name: 'featureText',
+  type: 'text',
   admin: {
     condition: (data) => data.enableFeature === true,
   },
-};
+}
 
 // Sibling data condition (from hero field pattern)
 const typeField: SelectField = {
-  name: "type",
-  type: "select",
-  options: ["none", "highImpact", "mediumImpact", "lowImpact"],
-  defaultValue: "lowImpact",
-};
+  name: 'type',
+  type: 'select',
+  options: ['none', 'highImpact', 'mediumImpact', 'lowImpact'],
+  defaultValue: 'lowImpact',
+}
 
 const mediaField: UploadField = {
-  name: "media",
-  type: "upload",
-  relationTo: "media",
+  name: 'media',
+  type: 'upload',
+  relationTo: 'media',
   admin: {
-    condition: (_, { type } = {}) =>
-      ["highImpact", "mediumImpact"].includes(type),
+    condition: (_, { type } = {}) => ['highImpact', 'mediumImpact'].includes(type),
   },
   required: true,
-};
+}
 ```
 
 ## Radio
@@ -471,21 +468,21 @@ const mediaField: UploadField = {
 Radio fields present options as radio buttons for single selection.
 
 ```ts
-import type { RadioField } from "payload";
+import type { RadioField } from 'payload'
 
 const radioField: RadioField = {
-  name: "priority",
-  type: "radio",
+  name: 'priority',
+  type: 'radio',
   options: [
-    { label: "Low", value: "low" },
-    { label: "Medium", value: "medium" },
-    { label: "High", value: "high" },
+    { label: 'Low', value: 'low' },
+    { label: 'Medium', value: 'medium' },
+    { label: 'High', value: 'high' },
   ],
-  defaultValue: "medium",
+  defaultValue: 'medium',
   admin: {
-    layout: "horizontal", // or 'vertical'
+    layout: 'horizontal', // or 'vertical'
   },
-};
+}
 ```
 
 ## Row (Layout)
@@ -493,23 +490,23 @@ const radioField: RadioField = {
 Row fields arrange fields horizontally in the admin panel (presentational only).
 
 ```ts
-import type { RowField } from "payload";
+import type { RowField } from 'payload'
 
 const rowField: RowField = {
-  type: "row",
+  type: 'row',
   fields: [
     {
-      name: "firstName",
-      type: "text",
-      admin: { width: "50%" },
+      name: 'firstName',
+      type: 'text',
+      admin: { width: '50%' },
     },
     {
-      name: "lastName",
-      type: "text",
-      admin: { width: "50%" },
+      name: 'lastName',
+      type: 'text',
+      admin: { width: '50%' },
     },
   ],
-};
+}
 ```
 
 ## Collapsible (Layout)
@@ -517,19 +514,19 @@ const rowField: RowField = {
 Collapsible fields group fields in an expandable/collapsible section.
 
 ```ts
-import type { CollapsibleField } from "payload";
+import type { CollapsibleField } from 'payload'
 
 const collapsibleField: CollapsibleField = {
-  label: ({ data }) => data?.title || "Advanced Options",
-  type: "collapsible",
+  label: ({ data }) => data?.title || 'Advanced Options',
+  type: 'collapsible',
   admin: {
     initCollapsed: true,
   },
   fields: [
-    { name: "customCSS", type: "textarea" },
-    { name: "customJS", type: "code" },
+    { name: 'customCSS', type: 'textarea' },
+    { name: 'customJS', type: 'code' },
   ],
-};
+}
 ```
 
 ## UI (Custom Components)
@@ -537,55 +534,55 @@ const collapsibleField: CollapsibleField = {
 UI fields allow fully custom React components in the admin (no data stored).
 
 ```ts
-import type { UIField } from "payload";
+import type { UIField } from 'payload'
 
 const uiField: UIField = {
-  name: "customMessage",
-  type: "ui",
+  name: 'customMessage',
+  type: 'ui',
   admin: {
     components: {
-      Field: "/path/to/CustomFieldComponent",
-      Cell: "/path/to/CustomCellComponent", // For list view
+      Field: '/path/to/CustomFieldComponent',
+      Cell: '/path/to/CustomCellComponent', // For list view
     },
   },
-};
+}
 ```
 
 ## Tabs & Groups
 
 ```ts
-import type { TabsField, GroupField } from "payload";
+import type { TabsField, GroupField } from 'payload'
 
 // Tabs
 const tabsField: TabsField = {
-  type: "tabs",
+  type: 'tabs',
   tabs: [
     {
-      label: "Content",
+      label: 'Content',
       fields: [
-        { name: "title", type: "text" },
-        { name: "body", type: "richText" },
+        { name: 'title', type: 'text' },
+        { name: 'body', type: 'richText' },
       ],
     },
     {
-      label: "SEO",
+      label: 'SEO',
       fields: [
-        { name: "metaTitle", type: "text" },
-        { name: "metaDescription", type: "textarea" },
+        { name: 'metaTitle', type: 'text' },
+        { name: 'metaDescription', type: 'textarea' },
       ],
     },
   ],
-};
+}
 
 // Group (named)
 const groupField: GroupField = {
-  name: "meta",
-  type: "group",
+  name: 'meta',
+  type: 'group',
   fields: [
-    { name: "title", type: "text" },
-    { name: "description", type: "textarea" },
+    { name: 'title', type: 'text' },
+    { name: 'description', type: 'textarea' },
   ],
-};
+}
 ```
 
 ## Reusable Field Factories
@@ -593,117 +590,113 @@ const groupField: GroupField = {
 Create composable field patterns that can be customized with overrides.
 
 ```ts
-import type { Field, GroupField } from "payload";
+import type { Field, GroupField } from 'payload'
 
 // Utility for deep merging
 const deepMerge = <T>(target: T, source: Partial<T>): T => {
   // Implementation would deeply merge objects
-  return { ...target, ...source };
-};
+  return { ...target, ...source }
+}
 
 // Reusable link field factory
 type LinkType = (options?: {
-  appearances?: ("default" | "outline")[] | false;
-  disableLabel?: boolean;
-  overrides?: Record<string, unknown>;
-}) => GroupField;
+  appearances?: ('default' | 'outline')[] | false
+  disableLabel?: boolean
+  overrides?: Record<string, unknown>
+}) => GroupField
 
-export const link: LinkType = ({
-  appearances,
-  disableLabel = false,
-  overrides = {},
-} = {}) => {
+export const link: LinkType = ({ appearances, disableLabel = false, overrides = {} } = {}) => {
   const linkField: GroupField = {
-    name: "link",
-    type: "group",
+    name: 'link',
+    type: 'group',
     admin: {
       hideGutter: true,
     },
     fields: [
       {
-        type: "row",
+        type: 'row',
         fields: [
           {
-            name: "type",
-            type: "radio",
+            name: 'type',
+            type: 'radio',
             options: [
-              { label: "Internal link", value: "reference" },
-              { label: "Custom URL", value: "custom" },
+              { label: 'Internal link', value: 'reference' },
+              { label: 'Custom URL', value: 'custom' },
             ],
-            defaultValue: "reference",
+            defaultValue: 'reference',
             admin: {
-              layout: "horizontal",
-              width: "50%",
+              layout: 'horizontal',
+              width: '50%',
             },
           },
           {
-            name: "newTab",
-            type: "checkbox",
-            label: "Open in new tab",
+            name: 'newTab',
+            type: 'checkbox',
+            label: 'Open in new tab',
             admin: {
-              width: "50%",
+              width: '50%',
               style: {
-                alignSelf: "flex-end",
+                alignSelf: 'flex-end',
               },
             },
           },
         ],
       },
       {
-        name: "reference",
-        type: "relationship",
-        relationTo: ["pages"],
+        name: 'reference',
+        type: 'relationship',
+        relationTo: ['pages'],
         required: true,
         maxDepth: 1,
         admin: {
-          condition: (_, siblingData) => siblingData?.type === "reference",
+          condition: (_, siblingData) => siblingData?.type === 'reference',
         },
       },
       {
-        name: "url",
-        type: "text",
-        label: "Custom URL",
+        name: 'url',
+        type: 'text',
+        label: 'Custom URL',
         required: true,
         admin: {
-          condition: (_, siblingData) => siblingData?.type === "custom",
+          condition: (_, siblingData) => siblingData?.type === 'custom',
         },
       },
     ],
-  };
+  }
 
   if (!disableLabel) {
     linkField.fields.push({
-      name: "label",
-      type: "text",
+      name: 'label',
+      type: 'text',
       required: true,
-    });
+    })
   }
 
   if (appearances !== false) {
     linkField.fields.push({
-      name: "appearance",
-      type: "select",
-      defaultValue: "default",
+      name: 'appearance',
+      type: 'select',
+      defaultValue: 'default',
       options: [
-        { label: "Default", value: "default" },
-        { label: "Outline", value: "outline" },
+        { label: 'Default', value: 'default' },
+        { label: 'Outline', value: 'outline' },
       ],
-    });
+    })
   }
 
-  return deepMerge(linkField, overrides) as GroupField;
-};
+  return deepMerge(linkField, overrides) as GroupField
+}
 
 // Usage
-const navItem = link({ appearances: false });
+const navItem = link({ appearances: false })
 const ctaButton = link({
   overrides: {
-    name: "cta",
+    name: 'cta',
     admin: {
-      description: "Call to action button",
+      description: 'Call to action button',
     },
   },
-});
+})
 ```
 
 ## Field Type Guards
@@ -733,17 +726,17 @@ Type guards for runtime field type checking and safe type narrowing.
 | `valueIsValueWithRelation`  | Value is polymorphic relationship                           | Handle polymorphic relationships         |
 
 ```ts
-import { fieldAffectsData, fieldHasSubFields, fieldIsArrayType } from "payload";
+import { fieldAffectsData, fieldHasSubFields, fieldIsArrayType } from 'payload'
 
 function processField(field: Field) {
   if (fieldAffectsData(field)) {
     // Safe to access field.name
-    console.log(field.name);
+    console.log(field.name)
   }
 
   if (fieldHasSubFields(field)) {
     // Safe to access field.fields
-    field.fields.forEach(processField);
+    field.fields.forEach(processField)
   }
 }
 ```

--- a/.agents/skills/payload/reference/HOOKS.md
+++ b/.agents/skills/payload/reference/HOOKS.md
@@ -6,81 +6,81 @@ Complete reference for collection hooks, field hooks, and hook context patterns.
 
 ```ts
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   hooks: {
     // Before validation
     beforeValidate: [
       async ({ data, operation }) => {
-        if (operation === "create") {
-          data.slug = slugify(data.title);
+        if (operation === 'create') {
+          data.slug = slugify(data.title)
         }
-        return data;
+        return data
       },
     ],
 
     // Before save
     beforeChange: [
       async ({ data, req, operation, originalDoc }) => {
-        if (operation === "update" && data.status === "published") {
-          data.publishedAt = new Date();
+        if (operation === 'update' && data.status === 'published') {
+          data.publishedAt = new Date()
         }
-        return data;
+        return data
       },
     ],
 
     // After save
     afterChange: [
       async ({ doc, req, operation, previousDoc }) => {
-        if (operation === "create") {
-          await sendNotification(doc);
+        if (operation === 'create') {
+          await sendNotification(doc)
         }
-        return doc;
+        return doc
       },
     ],
 
     // After read
     afterRead: [
       async ({ doc, req }) => {
-        doc.viewCount = await getViewCount(doc.id);
-        return doc;
+        doc.viewCount = await getViewCount(doc.id)
+        return doc
       },
     ],
 
     // Before delete
     beforeDelete: [
       async ({ req, id }) => {
-        await cleanupRelatedData(id);
+        await cleanupRelatedData(id)
       },
     ],
   },
-};
+}
 ```
 
 ## Field Hooks
 
 ```ts
-import type { EmailField, FieldHook } from "payload";
+import type { EmailField, FieldHook } from 'payload'
 
 const beforeValidateHook: FieldHook = ({ value }) => {
-  return value.trim().toLowerCase();
-};
+  return value.trim().toLowerCase()
+}
 
 const afterReadHook: FieldHook = ({ value, req }) => {
   // Hide email from non-admins
-  if (!req.user?.roles?.includes("admin")) {
-    return value.replace(/(.{2})(.*)(@.*)/, "$1***$3");
+  if (!req.user?.roles?.includes('admin')) {
+    return value.replace(/(.{2})(.*)(@.*)/, '$1***$3')
   }
-  return value;
-};
+  return value
+}
 
 const emailField: EmailField = {
-  name: "email",
-  type: "email",
+  name: 'email',
+  type: 'email',
   hooks: {
     beforeValidate: [beforeValidateHook],
     afterRead: [afterReadHook],
   },
-};
+}
 ```
 
 ## Hook Context
@@ -88,36 +88,33 @@ const emailField: EmailField = {
 Share data between hooks or control hook behavior using request context:
 
 ```ts
-import type { CollectionConfig } from "payload";
+import type { CollectionConfig } from 'payload'
 
 export const Posts: CollectionConfig = {
-  slug: "posts",
+  slug: 'posts',
   hooks: {
     beforeChange: [
       async ({ context }) => {
-        context.expensiveData = await fetchExpensiveData();
+        context.expensiveData = await fetchExpensiveData()
       },
     ],
     afterChange: [
       async ({ context, doc }) => {
         // Reuse from previous hook
-        await processData(doc, context.expensiveData);
+        await processData(doc, context.expensiveData)
       },
     ],
   },
-  fields: [{ name: "title", type: "text" }],
-};
+  fields: [{ name: 'title', type: 'text' }],
+}
 ```
 
 ## Next.js Revalidation with Context Control
 
 ```ts
-import type {
-  CollectionAfterChangeHook,
-  CollectionAfterDeleteHook,
-} from "payload";
-import { revalidatePath } from "next/cache";
-import type { Page } from "../payload-types";
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
+import { revalidatePath } from 'next/cache'
+import type { Page } from '../payload-types'
 
 export const revalidatePage: CollectionAfterChangeHook<Page> = ({
   doc,
@@ -125,33 +122,29 @@ export const revalidatePage: CollectionAfterChangeHook<Page> = ({
   req: { payload, context },
 }) => {
   if (!context.disableRevalidate) {
-    if (doc._status === "published") {
-      const path = doc.slug === "home" ? "/" : `/${doc.slug}`;
-      payload.logger.info(`Revalidating page at path: ${path}`);
-      revalidatePath(path);
+    if (doc._status === 'published') {
+      const path = doc.slug === 'home' ? '/' : `/${doc.slug}`
+      payload.logger.info(`Revalidating page at path: ${path}`)
+      revalidatePath(path)
     }
 
     // Revalidate old path if unpublished
-    if (previousDoc?._status === "published" && doc._status !== "published") {
-      const oldPath =
-        previousDoc.slug === "home" ? "/" : `/${previousDoc.slug}`;
-      payload.logger.info(`Revalidating old page at path: ${oldPath}`);
-      revalidatePath(oldPath);
+    if (previousDoc?._status === 'published' && doc._status !== 'published') {
+      const oldPath = previousDoc.slug === 'home' ? '/' : `/${previousDoc.slug}`
+      payload.logger.info(`Revalidating old page at path: ${oldPath}`)
+      revalidatePath(oldPath)
     }
   }
-  return doc;
-};
+  return doc
+}
 
-export const revalidateDelete: CollectionAfterDeleteHook<Page> = ({
-  doc,
-  req: { context },
-}) => {
+export const revalidateDelete: CollectionAfterDeleteHook<Page> = ({ doc, req: { context } }) => {
   if (!context.disableRevalidate) {
-    const path = doc?.slug === "home" ? "/" : `/${doc?.slug}`;
-    revalidatePath(path);
+    const path = doc?.slug === 'home' ? '/' : `/${doc?.slug}`
+    revalidatePath(path)
   }
-  return doc;
-};
+  return doc
+}
 ```
 
 ## Date Field Auto-Set
@@ -159,28 +152,28 @@ export const revalidateDelete: CollectionAfterDeleteHook<Page> = ({
 Automatically set date when document is published:
 
 ```ts
-import type { DateField } from "payload";
+import type { DateField } from 'payload'
 
 const publishedOnField: DateField = {
-  name: "publishedOn",
-  type: "date",
+  name: 'publishedOn',
+  type: 'date',
   admin: {
     date: {
-      pickerAppearance: "dayAndTime",
+      pickerAppearance: 'dayAndTime',
     },
-    position: "sidebar",
+    position: 'sidebar',
   },
   hooks: {
     beforeChange: [
       ({ siblingData, value }) => {
-        if (siblingData._status === "published" && !value) {
-          return new Date();
+        if (siblingData._status === 'published' && !value) {
+          return new Date()
         }
-        return value;
+        return value
       },
     ],
   },
-};
+}
 ```
 
 ## Hook Patterns Best Practices

--- a/.agents/skills/payload/reference/PLUGIN-DEVELOPMENT.md
+++ b/.agents/skills/payload/reference/PLUGIN-DEVELOPMENT.md
@@ -7,11 +7,11 @@ Complete guide to creating Payload plugins with TypeScript patterns, package str
 Plugins are functions that receive configuration options and return a function that transforms the Payload config:
 
 ```ts
-import type { Config, Plugin } from "payload";
+import type { Config, Plugin } from 'payload'
 
 interface MyPluginConfig {
-  enabled?: boolean;
-  collections?: string[];
+  enabled?: boolean
+  collections?: string[]
 }
 
 export const myPlugin =
@@ -19,7 +19,7 @@ export const myPlugin =
   (config: Config): Config => ({
     ...config,
     // Transform config here
-  });
+  })
 ```
 
 **Key Pattern:** Double arrow function (currying)
@@ -180,21 +180,21 @@ plugin-<name>/
 ### Adding Fields to Collections
 
 ```ts
-import type { Config, Plugin, Field } from "payload";
+import type { Config, Plugin, Field } from 'payload'
 
 export const seoPlugin =
   (options: { collections?: string[] }): Plugin =>
   (config: Config): Config => {
     const seoFields: Field[] = [
       {
-        name: "meta",
-        type: "group",
+        name: 'meta',
+        type: 'group',
         fields: [
-          { name: "title", type: "text" },
-          { name: "description", type: "textarea" },
+          { name: 'title', type: 'text' },
+          { name: 'description', type: 'textarea' },
         ],
       },
-    ];
+    ]
 
     return {
       ...config,
@@ -203,66 +203,62 @@ export const seoPlugin =
           return {
             ...collection,
             fields: [...(collection.fields || []), ...seoFields],
-          };
+          }
         }
-        return collection;
+        return collection
       }),
-    };
-  };
+    }
+  }
 ```
 
 ### Adding New Collections
 
 ```ts
-import type { Config, Plugin, CollectionConfig } from "payload";
+import type { Config, Plugin, CollectionConfig } from 'payload'
 
 export const redirectsPlugin =
   (options: { overrides?: Partial<CollectionConfig> }): Plugin =>
   (config: Config): Config => {
     const redirectsCollection: CollectionConfig = {
-      slug: "redirects",
+      slug: 'redirects',
       access: { read: () => true },
       fields: [
-        { name: "from", type: "text", required: true, unique: true },
-        { name: "to", type: "text", required: true },
+        { name: 'from', type: 'text', required: true, unique: true },
+        { name: 'to', type: 'text', required: true },
       ],
       ...options.overrides,
-    };
+    }
 
     return {
       ...config,
       collections: [...(config.collections || []), redirectsCollection],
-    };
-  };
+    }
+  }
 ```
 
 ### Adding Hooks
 
 ```ts
-import type { Config, Plugin, CollectionAfterChangeHook } from "payload";
+import type { Config, Plugin, CollectionAfterChangeHook } from 'payload'
 
-const resaveChildrenHook: CollectionAfterChangeHook = async ({
-  doc,
-  req,
-  operation,
-}) => {
-  if (operation === "update") {
+const resaveChildrenHook: CollectionAfterChangeHook = async ({ doc, req, operation }) => {
+  if (operation === 'update') {
     // Resave child documents
     const children = await req.payload.find({
-      collection: "pages",
+      collection: 'pages',
       where: { parent: { equals: doc.id } },
-    });
+    })
 
     for (const child of children.docs) {
       await req.payload.update({
-        collection: "pages",
+        collection: 'pages',
         id: child.id,
         data: child,
-      });
+      })
     }
   }
-  return doc;
-};
+  return doc
+}
 
 export const nestedDocsPlugin =
   (options: { collections: string[] }): Plugin =>
@@ -274,16 +270,13 @@ export const nestedDocsPlugin =
           ...collection,
           hooks: {
             ...(collection.hooks || {}),
-            afterChange: [
-              resaveChildrenHook,
-              ...(collection.hooks?.afterChange || []),
-            ],
+            afterChange: [resaveChildrenHook, ...(collection.hooks?.afterChange || [])],
           },
-        };
+        }
       }
-      return collection;
+      return collection
     }),
-  });
+  })
 ```
 
 ### Adding Root-Level Endpoints
@@ -291,28 +284,26 @@ export const nestedDocsPlugin =
 Add endpoints at the root config level (accessible at `/api/<path>`):
 
 ```ts
-import type { Config, Plugin, Endpoint } from "payload";
+import type { Config, Plugin, Endpoint } from 'payload'
 
 export const seoPlugin =
   (options: { generateTitle?: (doc: any) => string }): Plugin =>
   (config: Config): Config => {
     const generateTitleEndpoint: Endpoint = {
-      path: "/plugin-seo/generate-title",
-      method: "post",
+      path: '/plugin-seo/generate-title',
+      method: 'post',
       handler: async (req) => {
-        const data = await req.json?.();
-        const result = options.generateTitle
-          ? options.generateTitle(data.doc)
-          : "";
-        return Response.json({ result });
+        const data = await req.json?.()
+        const result = options.generateTitle ? options.generateTitle(data.doc) : ''
+        return Response.json({ result })
       },
-    };
+    }
 
     return {
       ...config,
       endpoints: [...(config.endpoints ?? []), generateTitleEndpoint],
-    };
-  };
+    }
+  }
 ```
 
 **Example webhook endpoint:**
@@ -320,45 +311,45 @@ export const seoPlugin =
 ```ts
 // Useful for integrations like Stripe
 const webhookEndpoint: Endpoint = {
-  path: "/stripe/webhook",
-  method: "post",
+  path: '/stripe/webhook',
+  method: 'post',
   handler: async (req) => {
-    const signature = req.headers.get("stripe-signature");
+    const signature = req.headers.get('stripe-signature')
     const event = stripe.webhooks.constructEvent(
       await req.text(),
       signature,
-      process.env.STRIPE_WEBHOOK_SECRET
-    );
+      process.env.STRIPE_WEBHOOK_SECRET,
+    )
     // Handle webhook
-    return Response.json({ received: true });
+    return Response.json({ received: true })
   },
-};
+}
 ```
 
 ### Field Overrides with Defaults
 
 ```ts
-import type { Config, Plugin, Field } from "payload";
+import type { Config, Plugin, Field } from 'payload'
 
-type FieldsOverride = (args: { defaultFields: Field[] }) => Field[];
+type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 
 interface PluginConfig {
-  collections?: string[];
-  fields?: FieldsOverride;
+  collections?: string[]
+  fields?: FieldsOverride
 }
 
 export const myPlugin =
   (options: PluginConfig): Plugin =>
   (config: Config): Config => {
     const defaultFields: Field[] = [
-      { name: "title", type: "text" },
-      { name: "description", type: "textarea" },
-    ];
+      { name: 'title', type: 'text' },
+      { name: 'description', type: 'textarea' },
+    ]
 
     const fields =
-      options.fields && typeof options.fields === "function"
+      options.fields && typeof options.fields === 'function'
         ? options.fields({ defaultFields })
-        : defaultFields;
+        : defaultFields
 
     return {
       ...config,
@@ -367,29 +358,29 @@ export const myPlugin =
           return {
             ...collection,
             fields: [...(collection.fields || []), ...fields],
-          };
+          }
         }
-        return collection;
+        return collection
       }),
-    };
-  };
+    }
+  }
 ```
 
 ### Tabs UI Pattern
 
 ```ts
-import type { Config, Plugin, TabsField, GroupField } from "payload";
+import type { Config, Plugin, TabsField, GroupField } from 'payload'
 
 export const seoPlugin =
   (options: { tabbedUI?: boolean }): Plugin =>
   (config: Config): Config => {
     const seoFields: GroupField[] = [
       {
-        name: "meta",
-        type: "group",
-        fields: [{ name: "title", type: "text" }],
+        name: 'meta',
+        type: 'group',
+        fields: [{ name: 'title', type: 'text' }],
       },
-    ];
+    ]
 
     return {
       ...config,
@@ -397,44 +388,42 @@ export const seoPlugin =
         if (options.tabbedUI) {
           const seoTabs: TabsField[] = [
             {
-              type: "tabs",
+              type: 'tabs',
               tabs: [
                 // If existing tabs, preserve them
-                ...(collection.fields?.[0]?.type === "tabs"
+                ...(collection.fields?.[0]?.type === 'tabs'
                   ? collection.fields[0].tabs
                   : [
                       {
-                        label: "Content",
+                        label: 'Content',
                         fields: collection.fields || [],
                       },
                     ]),
                 // Add SEO tab
                 {
-                  label: "SEO",
+                  label: 'SEO',
                   fields: seoFields,
                 },
               ],
             },
-          ];
+          ]
 
           return {
             ...collection,
             fields: [
               ...seoTabs,
-              ...(collection.fields?.[0]?.type === "tabs"
-                ? collection.fields.slice(1)
-                : []),
+              ...(collection.fields?.[0]?.type === 'tabs' ? collection.fields.slice(1) : []),
             ],
-          };
+          }
         }
 
         return {
           ...collection,
           fields: [...(collection.fields || []), ...seoFields],
-        };
+        }
       }),
-    };
-  };
+    }
+  }
 ```
 
 ### Disable Plugin Pattern
@@ -442,11 +431,11 @@ export const seoPlugin =
 Allow users to disable plugin without removing it (important for database schema consistency):
 
 ```ts
-import type { Config, Plugin } from "payload";
+import type { Config, Plugin } from 'payload'
 
 interface PluginConfig {
-  disabled?: boolean;
-  collections?: string[];
+  disabled?: boolean
+  collections?: string[]
 }
 
 export const myPlugin =
@@ -454,46 +443,44 @@ export const myPlugin =
   (config: Config): Config => {
     // Always add collections/fields for database schema consistency
     if (!config.collections) {
-      config.collections = [];
+      config.collections = []
     }
 
     config.collections.push({
-      slug: "plugin-collection",
-      fields: [{ name: "title", type: "text" }],
-    });
+      slug: 'plugin-collection',
+      fields: [{ name: 'title', type: 'text' }],
+    })
 
     // Add fields to specified collections
     if (options.collections) {
       for (const collectionSlug of options.collections) {
-        const collection = config.collections.find(
-          (c) => c.slug === collectionSlug
-        );
+        const collection = config.collections.find((c) => c.slug === collectionSlug)
         if (collection) {
           collection.fields.push({
-            name: "addedByPlugin",
-            type: "text",
-          });
+            name: 'addedByPlugin',
+            type: 'text',
+          })
         }
       }
     }
 
     // If disabled, return early but keep schema changes
     if (options.disabled) {
-      return config;
+      return config
     }
 
     // Add endpoints, hooks, components only when enabled
     config.endpoints = [
       ...(config.endpoints ?? []),
       {
-        path: "/my-endpoint",
-        method: "get",
-        handler: async () => Response.json({ message: "Hello" }),
+        path: '/my-endpoint',
+        method: 'get',
+        handler: async () => Response.json({ message: 'Hello' }),
       },
-    ];
+    ]
 
-    return config;
-  };
+    return config
+  }
 ```
 
 ### Admin Components
@@ -501,68 +488,64 @@ export const myPlugin =
 Add custom UI components to the admin panel:
 
 ```ts
-import type { Config, Plugin } from "payload";
+import type { Config, Plugin } from 'payload'
 
 export const myPlugin =
   (options: PluginConfig): Plugin =>
   (config: Config): Config => {
-    if (!config.admin) config.admin = {};
-    if (!config.admin.components) config.admin.components = {};
+    if (!config.admin) config.admin = {}
+    if (!config.admin.components) config.admin.components = {}
     if (!config.admin.components.beforeDashboard) {
-      config.admin.components.beforeDashboard = [];
+      config.admin.components.beforeDashboard = []
     }
 
     // Add client component
-    config.admin.components.beforeDashboard.push(
-      "my-plugin-name/client#BeforeDashboardClient"
-    );
+    config.admin.components.beforeDashboard.push('my-plugin-name/client#BeforeDashboardClient')
 
     // Add server component (RSC)
-    config.admin.components.beforeDashboard.push(
-      "my-plugin-name/rsc#BeforeDashboardServer"
-    );
+    config.admin.components.beforeDashboard.push('my-plugin-name/rsc#BeforeDashboardServer')
 
-    return config;
-  };
+    return config
+  }
 ```
 
 **Component file structure:**
 
 ```tsx
 // src/components/BeforeDashboardClient.tsx
-"use client";
-import { useConfig } from "@payloadcms/ui";
-import { useEffect, useState } from "react";
-import { formatAdminURL } from "payload/shared";
+'use client'
+import { useConfig } from '@payloadcms/ui'
+import { useEffect, useState } from 'react'
+import { formatAdminURL } from 'payload/shared'
 
 export const BeforeDashboardClient = () => {
-  const { config } = useConfig();
-  const [data, setData] = useState("");
+  const { config } = useConfig()
+  const [data, setData] = useState('')
 
   useEffect(() => {
     fetch(
       formatAdminURL({
         apiRoute: config.routes.api,
-        path: "/my-endpoint",
-      })
+        path: '/my-endpoint',
+      }),
     )
       .then((res) => res.json())
-      .then(setData);
-  }, [config.serverURL, config.routes.api]);
+      .then(setData)
+  }, [config.serverURL, config.routes.api])
 
-  return <div>Client Component: {data}</div>;
-};
+  return <div>Client Component: {data}</div>
+}
 
 // src/components/BeforeDashboardServer.tsx
 export const BeforeDashboardServer = () => {
-  return <div>Server Component</div>;
-};
+  return <div>Server Component</div>
+}
 
 // src/exports/client.ts
-export { BeforeDashboardClient } from "../components/BeforeDashboardClient.js";
+export { BeforeDashboardClient } from '../components/BeforeDashboardClient.js'
 
 // src/exports/rsc.ts
-export { BeforeDashboardServer } from "../components/BeforeDashboardServer.js";
+export { BeforeDashboardServer } from '../components/BeforeDashboardServer.js'
 ```
 
 ### Translations (i18n)
@@ -571,18 +554,18 @@ export { BeforeDashboardServer } from "../components/BeforeDashboardServer.js";
 // src/translations/index.ts
 export const translations = {
   en: {
-    "plugin-name:fieldLabel": "Field Label",
-    "plugin-name:fieldDescription": "Field description",
+    'plugin-name:fieldLabel': 'Field Label',
+    'plugin-name:fieldDescription': 'Field description',
   },
   es: {
-    "plugin-name:fieldLabel": "Etiqueta del campo",
-    "plugin-name:fieldDescription": "Descripción del campo",
+    'plugin-name:fieldLabel': 'Etiqueta del campo',
+    'plugin-name:fieldDescription': 'Descripción del campo',
   },
-};
+}
 
 // src/plugin.ts
-import { deepMergeSimple } from "payload/shared";
-import { translations } from "./translations/index.js";
+import { deepMergeSimple } from 'payload/shared'
+import { translations } from './translations/index.js'
 
 export const myPlugin =
   (options: PluginConfig): Plugin =>
@@ -590,12 +573,9 @@ export const myPlugin =
     ...config,
     i18n: {
       ...config.i18n,
-      translations: deepMergeSimple(
-        translations,
-        config.i18n?.translations ?? {}
-      ),
+      translations: deepMergeSimple(translations, config.i18n?.translations ?? {}),
     },
-  });
+  })
 ```
 
 ### onInit Hook
@@ -604,31 +584,31 @@ export const myPlugin =
 export const myPlugin =
   (options: PluginConfig): Plugin =>
   (config: Config): Config => {
-    const incomingOnInit = config.onInit;
+    const incomingOnInit = config.onInit
 
     config.onInit = async (payload) => {
       // IMPORTANT: Call existing onInit first
-      if (incomingOnInit) await incomingOnInit(payload);
+      if (incomingOnInit) await incomingOnInit(payload)
 
       // Plugin initialization
-      payload.logger.info("Plugin initialized");
+      payload.logger.info('Plugin initialized')
 
       // Example: Seed data
       const { totalDocs } = await payload.count({
-        collection: "plugin-collection",
-        where: { id: { equals: "seeded-by-plugin" } },
-      });
+        collection: 'plugin-collection',
+        where: { id: { equals: 'seeded-by-plugin' } },
+      })
 
       if (totalDocs === 0) {
         await payload.create({
-          collection: "plugin-collection",
-          data: { id: "seeded-by-plugin" },
-        });
+          collection: 'plugin-collection',
+          data: { id: 'seeded-by-plugin' },
+        })
       }
-    };
+    }
 
-    return config;
-  };
+    return config
+  }
 ```
 
 ## TypeScript Patterns
@@ -636,36 +616,31 @@ export const myPlugin =
 ### Plugin Config Types
 
 ```ts
-import type {
-  CollectionSlug,
-  GlobalSlug,
-  Field,
-  CollectionConfig,
-} from "payload";
+import type { CollectionSlug, GlobalSlug, Field, CollectionConfig } from 'payload'
 
-export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[];
+export type FieldsOverride = (args: { defaultFields: Field[] }) => Field[]
 
 export interface MyPluginConfig {
   /**
    * Collections to enable this plugin for
    */
-  collections?: CollectionSlug[];
+  collections?: CollectionSlug[]
   /**
    * Globals to enable this plugin for
    */
-  globals?: GlobalSlug[];
+  globals?: GlobalSlug[]
   /**
    * Override default fields
    */
-  fields?: FieldsOverride;
+  fields?: FieldsOverride
   /**
    * Enable tabbed UI
    */
-  tabbedUI?: boolean;
+  tabbedUI?: boolean
   /**
    * Override collection config
    */
-  overrides?: Partial<CollectionConfig>;
+  overrides?: Partial<CollectionConfig>
 }
 ```
 
@@ -673,10 +648,10 @@ export interface MyPluginConfig {
 
 ```ts
 // src/exports/types.ts
-export type { MyPluginConfig, FieldsOverride } from "../types.js";
+export type { MyPluginConfig, FieldsOverride } from '../types.js'
 
 // Usage
-import type { MyPluginConfig } from "@payloadcms/plugin-example/types";
+import type { MyPluginConfig } from '@payloadcms/plugin-example/types'
 ```
 
 ## Client Components
@@ -685,39 +660,36 @@ import type { MyPluginConfig } from "@payloadcms/plugin-example/types";
 
 ```tsx
 // src/fields/CustomField/Component.tsx
-"use client";
-import { useField } from "@payloadcms/ui";
-import type { TextFieldClientComponent } from "payload";
+'use client'
+import { useField } from '@payloadcms/ui'
+import type { TextFieldClientComponent } from 'payload'
 
-export const CustomFieldComponent: TextFieldClientComponent = ({
-  field,
-  path,
-}) => {
-  const { value, setValue } = useField<string>({ path });
+export const CustomFieldComponent: TextFieldClientComponent = ({ field, path }) => {
+  const { value, setValue } = useField<string>({ path })
 
   return (
     <div>
       <label>{field.label}</label>
-      <input value={value || ""} onChange={(e) => setValue(e.target.value)} />
+      <input value={value || ''} onChange={(e) => setValue(e.target.value)} />
     </div>
-  );
-};
+  )
+}
 ```
 
 ```ts
 // src/fields/CustomField/index.ts
-import type { Field } from "payload";
+import type { Field } from 'payload'
 
 export const CustomField = (overrides?: Partial<Field>): Field => ({
-  name: "customField",
-  type: "text",
+  name: 'customField',
+  type: 'text',
   admin: {
     components: {
-      Field: "/fields/CustomField/Component#CustomFieldComponent",
+      Field: '/fields/CustomField/Component#CustomFieldComponent',
     },
   },
   ...overrides,
-});
+})
 ```
 
 ## Best Practices
@@ -728,10 +700,10 @@ Always spread existing config and add to arrays:
 
 ```ts
 // ✅ Good
-collections: [...(config.collections || []), newCollection];
+collections: [...(config.collections || []), newCollection]
 
 // ❌ Bad
-collections: [newCollection];
+collections: [newCollection]
 ```
 
 ### Respect User Overrides
@@ -740,10 +712,10 @@ Allow users to override plugin defaults:
 
 ```ts
 const collection: CollectionConfig = {
-  slug: "redirects",
+  slug: 'redirects',
   fields: defaultFields,
   ...options.overrides, // User overrides last
-};
+}
 ```
 
 ### Conditional Logic
@@ -752,12 +724,12 @@ Check if collections/globals are enabled:
 
 ```ts
 collections: config.collections?.map((collection) => {
-  const isEnabled = options.collections?.includes(collection.slug);
+  const isEnabled = options.collections?.includes(collection.slug)
   if (isEnabled) {
     // Transform collection
   }
-  return collection;
-});
+  return collection
+})
 ```
 
 ### Hook Composition
@@ -779,14 +751,7 @@ hooks: {
 Use Payload's exported types:
 
 ```ts
-import type {
-  Config,
-  Plugin,
-  CollectionConfig,
-  Field,
-  CollectionSlug,
-  GlobalSlug,
-} from "payload";
+import type { Config, Plugin, CollectionConfig, Field, CollectionSlug, GlobalSlug } from 'payload'
 ```
 
 ### Field Path Imports
@@ -822,13 +787,13 @@ export const myPlugin =
     // Can await async operations during initialization
     const customCollection = await pluginConfig.collectionOverride?.({
       defaultCollection,
-    });
+    })
 
     return {
       ...incomingConfig,
       collections: [...incomingConfig.collections, customCollection],
-    };
-  };
+    }
+  }
 ```
 
 #### Collection Override with Async Support
@@ -837,20 +802,20 @@ Allow users to override entire collections with async functions:
 
 ```ts
 type CollectionOverride = (args: {
-  defaultCollection: CollectionConfig;
-}) => CollectionConfig | Promise<CollectionConfig>;
+  defaultCollection: CollectionConfig
+}) => CollectionConfig | Promise<CollectionConfig>
 
 interface PluginConfig {
   products?: {
-    collectionOverride?: CollectionOverride;
-  };
+    collectionOverride?: CollectionOverride
+  }
 }
 
 // In plugin
-const defaultCollection = createProductsCollection(config);
+const defaultCollection = createProductsCollection(config)
 const finalCollection = config.products?.collectionOverride
   ? await config.products.collectionOverride({ defaultCollection })
-  : defaultCollection;
+  : defaultCollection
 ```
 
 #### Config Sanitization Pattern
@@ -858,33 +823,31 @@ const finalCollection = config.products?.collectionOverride
 Normalize plugin configuration with defaults:
 
 ```ts
-export const sanitizePluginConfig = ({
-  pluginConfig,
-}: Props): SanitizedPluginConfig => {
-  const config = { ...pluginConfig } as Partial<SanitizedPluginConfig>;
+export const sanitizePluginConfig = ({ pluginConfig }: Props): SanitizedPluginConfig => {
+  const config = { ...pluginConfig } as Partial<SanitizedPluginConfig>
 
   // Normalize boolean|object configs
-  if (typeof config.addresses === "undefined" || config.addresses === true) {
-    config.addresses = { addressFields: defaultAddressFields() };
+  if (typeof config.addresses === 'undefined' || config.addresses === true) {
+    config.addresses = { addressFields: defaultAddressFields() }
   } else if (config.addresses === false) {
-    config.addresses = null;
+    config.addresses = null
   }
 
   // Validate required fields
   if (!config.stripeSecretKey) {
-    throw new Error("Stripe secret key is required");
+    throw new Error('Stripe secret key is required')
   }
 
-  return config as SanitizedPluginConfig;
-};
+  return config as SanitizedPluginConfig
+}
 
 // Use at plugin start
 export const myPlugin =
   (pluginConfig: PluginConfig): Plugin =>
   (config) => {
-    const sanitized = sanitizePluginConfig({ pluginConfig });
+    const sanitized = sanitizePluginConfig({ pluginConfig })
     // Use sanitized config throughout
-  };
+  }
 ```
 
 #### Collection Slug Mapping
@@ -922,27 +885,25 @@ Plugin operates on multiple collections with collection-specific config:
 ```ts
 interface PluginConfig {
   sync: Array<{
-    collection: string;
-    fields?: string[];
-    onSync?: (doc: any) => Promise<void>;
-  }>;
+    collection: string
+    fields?: string[]
+    onSync?: (doc: any) => Promise<void>
+  }>
 }
 
 // In plugin
 for (const collection of config.collections!) {
-  const syncConfig = pluginConfig.sync?.find(
-    (s) => s.collection === collection.slug
-  );
-  if (!syncConfig) continue;
+  const syncConfig = pluginConfig.sync?.find((s) => s.collection === collection.slug)
+  if (!syncConfig) continue
 
   collection.hooks.afterChange = [
     ...(collection.hooks?.afterChange || []),
     async ({ doc, operation }) => {
-      if (operation === "create" || operation === "update") {
-        await syncConfig.onSync?.(doc);
+      if (operation === 'create' || operation === 'update') {
+        await syncConfig.onSync?.(doc)
       }
     },
-  ];
+  ]
 }
 ```
 
@@ -953,27 +914,27 @@ for (const collection of config.collections!) {
 Add custom properties to generated TypeScript schema:
 
 ```ts
-incomingConfig.typescript = incomingConfig.typescript || {};
-incomingConfig.typescript.schema = incomingConfig.typescript.schema || [];
+incomingConfig.typescript = incomingConfig.typescript || {}
+incomingConfig.typescript.schema = incomingConfig.typescript.schema || []
 
 incomingConfig.typescript.schema.push((args) => {
-  const { jsonSchema } = args;
+  const { jsonSchema } = args
 
   jsonSchema.properties.ecommerce = {
-    type: "object",
+    type: 'object',
     properties: {
       collections: {
-        type: "object",
+        type: 'object',
         properties: {
-          products: { type: "string" },
-          orders: { type: "string" },
+          products: { type: 'string' },
+          orders: { type: 'string' },
         },
       },
     },
-  };
+  }
 
-  return jsonSchema;
-});
+  return jsonSchema
+})
 ```
 
 #### Module Declaration Augmentation
@@ -1018,8 +979,8 @@ return {
     afterError: [
       ...(config.hooks?.afterError ?? []),
       async (args) => {
-        const { error } = args;
-        const status = (error as APIError).status ?? 500;
+        const { error } = args
+        const status = (error as APIError).status ?? 500
 
         if (status >= 500 || captureErrors.includes(status)) {
           captureException(error, {
@@ -1028,12 +989,12 @@ return {
               operation: args.operation,
             },
             user: args.req?.user ? { id: args.req.user.id } : undefined,
-          });
+          })
         }
       },
     ],
   },
-};
+}
 ```
 
 #### Multiple Hook Types on Same Collection
@@ -1048,7 +1009,7 @@ collection.hooks = {
     ...(collection.hooks?.beforeValidate || []),
     async ({ data }) => {
       // Normalize before validation
-      return data;
+      return data
     },
   ],
 
@@ -1056,10 +1017,10 @@ collection.hooks = {
     ...(collection.hooks?.beforeChange || []),
     async ({ data, operation }) => {
       // Sync to external service
-      if (operation === "create") {
-        data.externalId = await externalService.create(data);
+      if (operation === 'create') {
+        data.externalId = await externalService.create(data)
       }
-      return data;
+      return data
     },
   ],
 
@@ -1067,7 +1028,7 @@ collection.hooks = {
     ...(collection.hooks?.afterChange || []),
     async ({ doc }) => {
       // Invalidate cache
-      await cache.invalidate(`doc:${doc.id}`);
+      await cache.invalidate(`doc:${doc.id}`)
     },
   ],
 
@@ -1075,10 +1036,10 @@ collection.hooks = {
     ...(collection.hooks?.afterDelete || []),
     async ({ doc }) => {
       // Cleanup external resources
-      await externalService.delete(doc.externalId);
+      await externalService.delete(doc.externalId)
     },
   ],
-};
+}
 ```
 
 ### Access Control & Filtering
@@ -1095,7 +1056,7 @@ export const multiTenantPlugin =
     ...config,
     collections: (config.collections || []).map((collection) => {
       if (!pluginOptions.collections.includes(collection.slug)) {
-        return collection;
+        return collection
       }
 
       return {
@@ -1109,12 +1070,12 @@ export const multiTenantPlugin =
                 collection.access?.read ? collection.access.read({ req }) : {},
                 { tenant: { equals: req.user?.tenant } },
               ],
-            };
+            }
           },
         },
-      };
+      }
     }),
-  });
+  })
 ```
 
 #### BaseFilter Composition
@@ -1123,15 +1084,13 @@ Combine plugin filters with existing baseListFilter:
 
 ```ts
 // From plugin-multi-tenant
-const existingBaseFilter = collection.admin?.baseListFilter;
-const tenantFilter = { tenant: { equals: req.user?.tenant } };
+const existingBaseFilter = collection.admin?.baseListFilter
+const tenantFilter = { tenant: { equals: req.user?.tenant } }
 
 collection.admin = {
   ...collection.admin,
-  baseListFilter: existingBaseFilter
-    ? { and: [existingBaseFilter, tenantFilter] }
-    : tenantFilter,
-};
+  baseListFilter: existingBaseFilter ? { and: [existingBaseFilter, tenantFilter] } : tenantFilter,
+}
 ```
 
 #### Relationship FilterOptions Modification
@@ -1141,21 +1100,18 @@ Add filters to relationship field options:
 ```ts
 // From plugin-multi-tenant
 collection.fields = collection.fields.map((field) => {
-  if (field.type === "relationship") {
+  if (field.type === 'relationship') {
     return {
       ...field,
       filterOptions: ({ relationTo }) => {
         return {
-          and: [
-            field.filterOptions?.(relationTo) || {},
-            { tenant: { equals: req.user?.tenant } },
-          ],
-        };
+          and: [field.filterOptions?.(relationTo) || {}, { tenant: { equals: req.user?.tenant } }],
+        }
       },
-    };
+    }
   }
-  return field;
-});
+  return field
+})
 ```
 
 ### Admin UI Customization
@@ -1177,14 +1133,13 @@ export const nestedDocsPlugin =
         meta: {
           ...collection.admin?.meta,
           nestedDocs: {
-            breadcrumbsFieldSlug:
-              pluginOptions.breadcrumbsFieldSlug || "breadcrumbs",
-            parentFieldSlug: pluginOptions.parentFieldSlug || "parent",
+            breadcrumbsFieldSlug: pluginOptions.breadcrumbsFieldSlug || 'breadcrumbs',
+            parentFieldSlug: pluginOptions.parentFieldSlug || 'parent',
           },
         },
       },
     })),
-  });
+  })
 ```
 
 #### Conditional Component Rendering
@@ -1193,10 +1148,10 @@ Add components based on plugin configuration:
 
 ```ts
 // From plugin-seo
-const beforeFields = collection.admin?.components?.beforeFields || [];
+const beforeFields = collection.admin?.components?.beforeFields || []
 
 if (pluginOptions.uploadsCollection === collection.slug) {
-  beforeFields.push("/path/to/ImagePreview#ImagePreview");
+  beforeFields.push('/path/to/ImagePreview#ImagePreview')
 }
 
 collection.admin = {
@@ -1205,7 +1160,7 @@ collection.admin = {
     ...collection.admin?.components,
     beforeFields,
   },
-};
+}
 ```
 
 #### Custom Provider Pattern
@@ -1220,10 +1175,10 @@ collection.admin = {
     ...collection.admin?.components,
     providers: [
       ...(collection.admin?.components?.providers || []),
-      "/components/NestedDocsProvider#NestedDocsProvider",
+      '/components/NestedDocsProvider#NestedDocsProvider',
     ],
   },
-};
+}
 ```
 
 #### Custom Actions
@@ -1238,11 +1193,11 @@ collection.admin = {
     ...collection.admin?.components,
     actions: [
       ...(collection.admin?.components?.actions || []),
-      "/components/ImportButton#ImportButton",
-      "/components/ExportButton#ExportButton",
+      '/components/ImportButton#ImportButton',
+      '/components/ExportButton#ExportButton',
     ],
   },
-};
+}
 ```
 
 #### Custom List Item Views
@@ -1259,11 +1214,11 @@ collection.admin = {
       ...collection.admin?.components?.views,
       list: {
         ...collection.admin?.components?.views?.list,
-        Component: "/views/ProductList#ProductList",
+        Component: '/views/ProductList#ProductList',
       },
     },
   },
-};
+}
 ```
 
 #### Custom Collection Endpoints
@@ -1275,22 +1230,22 @@ Add collection-scoped endpoints (accessible at `/api/<collection-slug>/<path>`):
 collection.endpoints = [
   ...(collection.endpoints || []),
   {
-    path: "/import",
-    method: "post",
+    path: '/import',
+    method: 'post',
     handler: async (req) => {
       // Import logic accessible at /api/posts/import
-      return Response.json({ success: true });
+      return Response.json({ success: true })
     },
   },
   {
-    path: "/export",
-    method: "get",
+    path: '/export',
+    method: 'get',
     handler: async (req) => {
       // Export logic accessible at /api/posts/export
-      return Response.json({ data: exportedData });
+      return Response.json({ data: exportedData })
     },
   },
-];
+]
 ```
 
 ### Field & Collection Modifications
@@ -1303,10 +1258,10 @@ Control admin UI organization:
 // From plugin-redirects
 collection.admin = {
   ...collection.admin,
-  group: pluginOptions.group || "Settings",
+  group: pluginOptions.group || 'Settings',
   hidden: pluginOptions.hidden,
-  defaultColumns: pluginOptions.defaultColumns || ["from", "to", "updatedAt"],
-};
+  defaultColumns: pluginOptions.defaultColumns || ['from', 'to', 'updatedAt'],
+}
 ```
 
 ### Background Jobs & Async Operations
@@ -1326,16 +1281,16 @@ export const stripePlugin =
       tasks: [
         ...(config.jobs?.tasks || []),
         {
-          slug: "syncStripeProducts",
+          slug: 'syncStripeProducts',
           handler: async ({ req }) => {
-            const products = await stripe.products.list();
+            const products = await stripe.products.list()
             // Sync to Payload
-            return { output: { synced: products.data.length } };
+            return { output: { synced: products.data.length } }
           },
         },
       ],
     },
-  });
+  })
 ```
 
 ## Testing Plugins
@@ -1354,25 +1309,25 @@ PAYLOAD_SECRET=your-secret-here
 2. Configure `dev/payload.config.ts`:
 
 ```ts
-import { buildConfig } from "payload";
-import { mongooseAdapter } from "@payloadcms/db-mongodb";
-import { myPlugin } from "../src/index.js";
+import { buildConfig } from 'payload'
+import { mongooseAdapter } from '@payloadcms/db-mongodb'
+import { myPlugin } from '../src/index.js'
 
 export default buildConfig({
   secret: process.env.PAYLOAD_SECRET!,
   db: mongooseAdapter({ url: process.env.DATABASE_URL! }),
   plugins: [
     myPlugin({
-      collections: ["posts"],
+      collections: ['posts'],
     }),
   ],
   collections: [
     {
-      slug: "posts",
-      fields: [{ name: "title", type: "text" }],
+      slug: 'posts',
+      fields: [{ name: 'title', type: 'text' }],
     },
   ],
-});
+})
 ```
 
 3. Run development server:
@@ -1386,48 +1341,48 @@ npm run dev  # Starts Next.js on http://localhost:3000
 Create `dev/int.spec.ts`:
 
 ```ts
-import type { Payload } from "payload";
-import config from "@payload-config";
-import { createPayloadRequest, getPayload } from "payload";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
-import { customEndpointHandler } from "../src/endpoints/handler.js";
+import type { Payload } from 'payload'
+import config from '@payload-config'
+import { createPayloadRequest, getPayload } from 'payload'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { customEndpointHandler } from '../src/endpoints/handler.js'
 
-let payload: Payload;
+let payload: Payload
 
 beforeAll(async () => {
-  payload = await getPayload({ config });
-});
+  payload = await getPayload({ config })
+})
 
 afterAll(async () => {
-  await payload.destroy();
-});
+  await payload.destroy()
+})
 
-describe("Plugin integration tests", () => {
-  test("should add field to collection", async () => {
+describe('Plugin integration tests', () => {
+  test('should add field to collection', async () => {
     const post = await payload.create({
-      collection: "posts",
+      collection: 'posts',
       data: {
-        title: "Test",
-        addedByPlugin: "plugin value",
+        title: 'Test',
+        addedByPlugin: 'plugin value',
       },
-    });
-    expect(post.addedByPlugin).toBe("plugin value");
-  });
+    })
+    expect(post.addedByPlugin).toBe('plugin value')
+  })
 
-  test("should create plugin collection", async () => {
-    expect(payload.collections["plugin-collection"]).toBeDefined();
-    const { docs } = await payload.find({ collection: "plugin-collection" });
-    expect(docs.length).toBeGreaterThan(0);
-  });
+  test('should create plugin collection', async () => {
+    expect(payload.collections['plugin-collection']).toBeDefined()
+    const { docs } = await payload.find({ collection: 'plugin-collection' })
+    expect(docs.length).toBeGreaterThan(0)
+  })
 
-  test("should query custom endpoint", async () => {
-    const request = new Request("http://localhost:3000/api/my-endpoint");
-    const payloadRequest = await createPayloadRequest({ config, request });
-    const response = await customEndpointHandler(payloadRequest);
-    const data = await response.json();
-    expect(data).toMatchObject({ message: "Hello" });
-  });
-});
+  test('should query custom endpoint', async () => {
+    const request = new Request('http://localhost:3000/api/my-endpoint')
+    const payloadRequest = await createPayloadRequest({ config, request })
+    const response = await customEndpointHandler(payloadRequest)
+    const data = await response.json()
+    expect(data).toMatchObject({ message: 'Hello' })
+  })
+})
 ```
 
 Run: `npm run test:int`
@@ -1437,14 +1392,14 @@ Run: `npm run test:int`
 Create `dev/e2e.spec.ts`:
 
 ```ts
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test'
 
-test.describe("Plugin e2e tests", () => {
-  test("should render custom admin component", async ({ page }) => {
-    await page.goto("http://localhost:3000/admin");
-    await expect(page.getByText("Added by the plugin")).toBeVisible();
-  });
-});
+test.describe('Plugin e2e tests', () => {
+  test('should render custom admin component', async ({ page }) => {
+    await page.goto('http://localhost:3000/admin')
+    await expect(page.getByText('Added by the plugin')).toBeVisible()
+  })
+})
 ```
 
 Run: `npm run test:e2e`

--- a/.agents/skills/payload/reference/QUERIES.md
+++ b/.agents/skills/payload/reference/QUERIES.md
@@ -5,58 +5,58 @@ Complete reference for querying data across Local API, REST, and GraphQL.
 ## Query Operators
 
 ```ts
-import type { Where } from "payload";
+import type { Where } from 'payload'
 
 // Equals
-const equalsQuery: Where = { color: { equals: "blue" } };
+const equalsQuery: Where = { color: { equals: 'blue' } }
 
 // Not equals
-const notEqualsQuery: Where = { status: { not_equals: "draft" } };
+const notEqualsQuery: Where = { status: { not_equals: 'draft' } }
 
 // Greater/less than
-const greaterThanQuery: Where = { price: { greater_than: 100 } };
-const lessThanEqualQuery: Where = { age: { less_than_equal: 65 } };
+const greaterThanQuery: Where = { price: { greater_than: 100 } }
+const lessThanEqualQuery: Where = { age: { less_than_equal: 65 } }
 
 // Contains (case-insensitive)
-const containsQuery: Where = { title: { contains: "payload" } };
+const containsQuery: Where = { title: { contains: 'payload' } }
 
 // Like (all words present)
-const likeQuery: Where = { description: { like: "cms headless" } };
+const likeQuery: Where = { description: { like: 'cms headless' } }
 
 // In/not in
-const inQuery: Where = { category: { in: ["tech", "news"] } };
+const inQuery: Where = { category: { in: ['tech', 'news'] } }
 
 // Exists
-const existsQuery: Where = { image: { exists: true } };
+const existsQuery: Where = { image: { exists: true } }
 
 // Near (point fields)
-const nearQuery: Where = { location: { near: "-122.4194,37.7749,10000" } };
+const nearQuery: Where = { location: { near: '-122.4194,37.7749,10000' } }
 ```
 
 ## AND/OR Logic
 
 ```ts
-import type { Where } from "payload";
+import type { Where } from 'payload'
 
 const complexQuery: Where = {
   or: [
-    { color: { equals: "mint" } },
+    { color: { equals: 'mint' } },
     {
-      and: [{ color: { equals: "white" } }, { featured: { equals: false } }],
+      and: [{ color: { equals: 'white' } }, { featured: { equals: false } }],
     },
   ],
-};
+}
 ```
 
 ## Nested Properties
 
 ```ts
-import type { Where } from "payload";
+import type { Where } from 'payload'
 
 const nestedQuery: Where = {
-  "author.role": { equals: "editor" },
-  "meta.featured": { exists: true },
-};
+  'author.role': { equals: 'editor' },
+  'meta.featured': { exists: true },
+}
 ```
 
 ## Local API
@@ -64,60 +64,60 @@ const nestedQuery: Where = {
 ```ts
 // Find documents
 const posts = await payload.find({
-  collection: "posts",
+  collection: 'posts',
   where: {
-    status: { equals: "published" },
-    "author.name": { contains: "john" },
+    status: { equals: 'published' },
+    'author.name': { contains: 'john' },
   },
   depth: 2,
   limit: 10,
   page: 1,
-  sort: "-createdAt",
-  locale: "en",
+  sort: '-createdAt',
+  locale: 'en',
   select: {
     title: true,
     author: true,
   },
-});
+})
 
 // Find by ID
 const post = await payload.findByID({
-  collection: "posts",
-  id: "123",
+  collection: 'posts',
+  id: '123',
   depth: 2,
-});
+})
 
 // Create
 const post = await payload.create({
-  collection: "posts",
+  collection: 'posts',
   data: {
-    title: "New Post",
-    status: "draft",
+    title: 'New Post',
+    status: 'draft',
   },
-});
+})
 
 // Update
 await payload.update({
-  collection: "posts",
-  id: "123",
+  collection: 'posts',
+  id: '123',
   data: {
-    status: "published",
+    status: 'published',
   },
-});
+})
 
 // Delete
 await payload.delete({
-  collection: "posts",
-  id: "123",
-});
+  collection: 'posts',
+  id: '123',
+})
 
 // Count
 const count = await payload.count({
-  collection: "posts",
+  collection: 'posts',
   where: {
-    status: { equals: "published" },
+    status: { equals: 'published' },
   },
-});
+})
 ```
 
 ### Threading req Parameter
@@ -128,20 +128,20 @@ When performing operations in hooks or nested operations, pass the `req` paramet
 // ✅ CORRECT: Pass req for transaction safety
 const afterChange: CollectionAfterChangeHook = async ({ doc, req }) => {
   await req.payload.create({
-    collection: "audit-log",
-    data: { action: "created", docId: doc.id },
+    collection: 'audit-log',
+    data: { action: 'created', docId: doc.id },
     req, // Maintains transaction atomicity
-  });
-};
+  })
+}
 
 // ❌ WRONG: Missing req breaks transaction
 const afterChange: CollectionAfterChangeHook = async ({ doc, req }) => {
   await req.payload.create({
-    collection: "audit-log",
-    data: { action: "created", docId: doc.id },
+    collection: 'audit-log',
+    data: { action: 'created', docId: doc.id },
     // Missing req - runs in separate transaction
-  });
-};
+  })
+}
 ```
 
 This is critical for MongoDB replica sets and Postgres. See [ADAPTERS.md#threading-req-through-operations](ADAPTERS.md#threading-req-through-operations) for details.
@@ -153,27 +153,27 @@ This is critical for MongoDB replica sets and Postgres. See [ADAPTERS.md#threadi
 ```ts
 // ❌ WRONG: User is passed but access control is bypassed
 const posts = await payload.find({
-  collection: "posts",
+  collection: 'posts',
   user: currentUser,
   // Missing: overrideAccess: false
   // Result: Operation runs with ADMIN privileges, ignoring user's permissions
-});
+})
 
 // ✅ CORRECT: Respects user's access control permissions
 const posts = await payload.find({
-  collection: "posts",
+  collection: 'posts',
   user: currentUser,
   overrideAccess: false, // Required to enforce access control
   // Result: User only sees posts they have permission to read
-});
+})
 
 // Administrative operation (intentionally bypass access control)
 const allPosts = await payload.find({
-  collection: "posts",
+  collection: 'posts',
   // No user parameter
   // overrideAccess defaults to true
   // Result: Returns all posts regardless of access control
-});
+})
 ```
 
 **When to use `overrideAccess: false`:**
@@ -194,11 +194,11 @@ See [ACCESS-CONTROL.md#important-notes](ACCESS-CONTROL.md#important-notes) for m
 ## REST API
 
 ```ts
-import { stringify } from "qs-esm";
+import { stringify } from 'qs-esm'
 
 const query = {
-  status: { equals: "published" },
-};
+  status: { equals: 'published' },
+}
 
 const queryString = stringify(
   {
@@ -206,11 +206,11 @@ const queryString = stringify(
     depth: 2,
     limit: 10,
   },
-  { addQueryPrefix: true }
-);
+  { addQueryPrefix: true },
+)
 
-const response = await fetch(`https://api.example.com/api/posts${queryString}`);
-const data = await response.json();
+const response = await fetch(`https://api.example.com/api/posts${queryString}`)
+const data = await response.json()
 ```
 
 ### REST Endpoints
@@ -231,11 +231,7 @@ POST   /api/globals/{slug}         - Update global
 
 ```graphql
 query {
-  Posts(
-    where: { status: { equals: published } }
-    limit: 10
-    sort: "-createdAt"
-  ) {
+  Posts(where: { status: { equals: published } }, limit: 10, sort: "-createdAt") {
     docs {
       id
       title


### PR DESCRIPTION
## Summary
- Refresh the `payload` skill with the latest core guidance from the Payload skills repo.
- Update the reference docs covering access control, collections, fields, hooks, queries, endpoints, adapters, and plugin development.
- Keep the local skill aligned with current Payload patterns and terminology.

## Testing
- Not run (not requested)