### PR TITLE
chore: improve Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,84 +26,57 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
-      security-patches:
+      security-updates:
         applies-to: security-updates
         patterns:
           - "*"
         update-types:
           - "patch"
           - "minor"
-      payload-cms:
+      backend-admin:
         patterns:
           - "payload"
           - "@payloadcms/*"
+          - "nodemailer"
+          - "@libsql/client"
+          - "graphql"
         update-types:
           - "patch"
           - "minor"
-      next-react:
+      frontend:
         patterns:
           - "next"
           - "@next/*"
-          - "eslint-config-next"
           - "react"
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
-        update-types:
-          - "patch"
-          - "minor"
-      vercel-observability:
-        patterns:
-          - "@vercel/*"
-        update-types:
-          - "patch"
-          - "minor"
-      app-runtime:
-        dependency-type: "production"
-        update-types:
-          - "patch"
-          - "minor"
-        exclude-patterns:
-          - "payload"
-          - "@payloadcms/*"
-          - "next"
-          - "@next/*"
-          - "react"
-          - "react-dom"
-          - "@vercel/*"
-      test-tooling:
-        patterns:
-          - "@playwright/test"
-          - "playwright"
-        update-types:
-          - "patch"
-          - "minor"
-      style-tooling:
-        patterns:
-          - "tailwindcss"
+          - "framer-motion"
+          - "clsx"
           - "tailwind-merge"
+          - "tailwindcss"
+          - "@tailwindcss/*"
           - "postcss"
           - "autoprefixer"
           - "prettier-plugin-tailwindcss"
+          - "@vercel/*"
         update-types:
           - "patch"
           - "minor"
-      dev-tooling:
-        dependency-type: "development"
-        update-types:
-          - "patch"
-          - "minor"
-        exclude-patterns:
+      quality-and-test:
+        patterns:
+          - "eslint"
+          - "eslint-config-next"
+          - "typescript"
+          - "@types/node"
+          - "prettier"
+          - "husky"
+          - "lint-staged"
           - "@playwright/test"
           - "playwright"
-          - "tailwindcss"
-          - "postcss"
-          - "autoprefixer"
-          - "prettier-plugin-tailwindcss"
-          - "@next/*"
-          - "eslint-config-next"
-          - "@types/react"
-          - "@types/react-dom"
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -125,3 +98,6 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,16 +6,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "06:00"
+      time: "09:00"
       timezone: "Europe/Brussels"
-    open-pull-requests-limit: 6
+    open-pull-requests-limit: 5
     versioning-strategy: "increase-if-necessary"
+    rebase-strategy: "auto"
+    assignees:
+      - "robinpellegrims"
     labels:
       - "dependencies"
       - "npm"
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps-dev"
+      prefix: "chore"
+      prefix-development: "chore"
       include: "scope"
     cooldown:
       default-days: 5
@@ -105,10 +108,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
-      time: "06:30"
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
       timezone: "Europe/Brussels"
     open-pull-requests-limit: 3
+    assignees:
+      - "robinpellegrims"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/assign-dependabot.yml
+++ b/.github/workflows/assign-dependabot.yml
@@ -1,0 +1,31 @@
+name: Assign Dependabot PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  assign:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign by validation domain
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" == *"backend-admin"* || "$PR_TITLE" == *"frontend"* ]]; then
+            assignee="wardpel"
+          else
+            assignee="robinpellegrims"
+          fi
+
+          gh pr edit "$PR_URL" --add-assignee "$assignee"


### PR DESCRIPTION
## Summary
- Schedule npm updates on Monday at 09:00 and GitHub Actions updates at 09:30 Brussels time
- Reduce the open npm PR limit to keep dependency review manageable
- Enable automatic Dependabot rebases
- Assign Dependabot PRs to robinpellegrims
- Standardize npm update commits on the chore prefix
- Preserve the existing focused dependency groups and cooldown policy

## Validation
- Dependabot configuration validation will run on this pull request.